### PR TITLE
Use a lambda function for maybeEnough

### DIFF
--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -299,12 +299,12 @@ export default class TypeScriptService {
         }
         const configuration = configurations[index];
 
-        function maybeEnough() {
+        const maybeEnough = () => {
             if (limit && items.length >= limit || index == configurations.length - 1) {
                 return callback();
             }
             this.collectWorkspaceSymbols(query, limit, configurations, index + 1, items, callback);
-        }
+        };
 
         configuration.get().then(() => {
             setImmediate(() => {


### PR DESCRIPTION
The current version fails quite often due to `this` changing. Using a lambda
function gives us lexical scoping (I think).