### PR TITLE
Performance optimization and bug fixes

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -309,7 +309,7 @@ export class ProjectManager {
                 this.remoteFs.readFile(path, (err?: Error, result?: string) => {
                     if (err) {
                         console.error('Unable to fetch content of ' + path, err);
-                        // There is a chance that we request unexistent file.
+                        // There is a chance that we request not-existent file.
                         result = '';
                     }
                     const rel = path_.posix.relative(this.root, path);

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -53,6 +53,11 @@ export class ProjectManager {
         return this.root;
     }
 
+
+    getFs(): InMemoryFileSystem {
+        return this.localFs;
+    }
+
 	/**
 	 * @return true if there is a file with a given name
 	 */
@@ -304,7 +309,8 @@ export class ProjectManager {
                 this.remoteFs.readFile(path, (err?: Error, result?: string) => {
                     if (err) {
                         console.error('Unable to fetch content of ' + path, err);
-                        return callback(err)
+                        // There is a chance that we request unexistent file.
+                        result = '';
                     }
                     const rel = path_.posix.relative(this.root, path);
                     this.localFs.addFile(rel, result);
@@ -447,12 +453,26 @@ class InMemoryLanguageServiceHost implements ts.LanguageServiceHost {
     getDefaultLibFileName(options: ts.CompilerOptions): string {
         return util.normalizePath(ts.getDefaultLibFilePath(options));
     }
+
+    trace(message: string) {
+        console.error(message);
+    }
+
+    log(message: string) {
+        console.error(message);
+    }
+
+    error(message: string) {
+        console.error(message);
+    }
+
+
 }
 
 /**
  * In-memory file system, can be served as a ParseConfigHost (thus allowing listing files that belong to project based on tsconfig.json options)
  */
-class InMemoryFileSystem implements ts.ParseConfigHost {
+export class InMemoryFileSystem implements ts.ParseConfigHost, ts.ModuleResolutionHost {
 
     entries: any;
     overlay: any;
@@ -500,7 +520,6 @@ class InMemoryFileSystem implements ts.ParseConfigHost {
     }
 
     readFile(path: string): string {
-
         let content = this.overlay[path];
         if (content !== undefined) {
             return content;
@@ -565,6 +584,10 @@ class InMemoryFileSystem implements ts.ParseConfigHost {
             }
         });
         return ret;
+    }
+
+    trace(message: string) {
+        console.error(message);
     }
 }
 

--- a/src/test/language-server-test.ts
+++ b/src/test/language-server-test.ts
@@ -498,7 +498,7 @@ describe('LSP', function () {
                 'a.ts': "function foo(n: Node): {console.log(n.parentNode})}"
             }, done);
         });
-        it('thou shall load local library file', function (done: (err?: Error) => void) {
+        it('loads local library file', function (done: (err?: Error) => void) {
             utils.hover({
                 textDocument: {
                     uri: 'file:///a.ts'

--- a/src/test/language-server-test.ts
+++ b/src/test/language-server-test.ts
@@ -487,4 +487,35 @@ describe('LSP', function () {
             utils.tearDown(done);
         });
     });
+    describe('typescript libs', function () {
+        before(function (done: () => void) {
+            utils.setUp({
+                'tsconfig.json': JSON.stringify({
+                    compilerOptions: {
+                        lib: ['es2016', 'dom']
+                    }
+                }),
+                'a.ts': "function foo(n: Node): {console.log(n.parentNode})}"
+            }, done);
+        });
+        it('thou shall load local library file', function (done: (err?: Error) => void) {
+            utils.hover({
+                textDocument: {
+                    uri: 'file:///a.ts'
+                },
+                position: {
+                    line: 0,
+                    character: 16
+                }
+            }, {
+                    contents: [{
+                        language: 'typescript',
+                        value: 'interface Node\nvar Node: {\n    new (): Node;\n    prototype: Node;\n    readonly ATTRIBUTE_NODE: number;\n    readonly CDATA_SECTION_NODE: number;\n    readonly COMMENT_NODE: number;\n    readonly DOCUMENT_FRAGMENT_NODE: number;\n    readonly DOCUMENT_NODE: number;\n    readonly DOCUMENT_POSITION_CONTAINED_BY: number;\n    readonly DOCUMENT_POSITION_CONTAINS: number;\n    readonly DOCUMENT_POSITION_DISCONNECTED: number;\n    readonly DOCUMENT_POSITION_FOLLOWING: number;\n    readonly DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: number;\n    readonly DOCUMENT_POSITION_PRECEDING: number;\n    readonly DOCUMENT_TYPE_NODE: number;\n    readonly ELEMENT_NODE: number;\n    readonly ENTITY_NODE: number;\n    readonly ENTITY_REFERENCE_NODE: number;\n    readonly NOTATION_NODE: number;\n    readonly PROCESSING_INSTRUCTION_NODE: number;\n    readonly TEXT_NODE: number;\n}'
+                    }]
+                }, done);
+        });
+        afterEach(function (done: () => void) {
+            utils.tearDown(done);
+        });
+    });
 });

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -151,9 +151,11 @@ export function definition(pos: vscode.TextDocumentPositionParams, expected: vsc
         }
     }).then((results: vscode.Location[]) => {
         check(done, () => {
-            chai.expect(results.length).to.equal(1);
-            const result = results[0];
-            chai.expect(result).to.deep.equal(expected);
+            chai.expect(results.length).to.equal(expected ? 1 : 0);
+            if (expected) {
+                const result = results[0];
+                chai.expect(result).to.deep.equal(expected);
+            }
         });
     }, (err?: Error) => {
         return done(err || new Error('definition request failed'))


### PR DESCRIPTION
- there is no need to synchronize configuration when looking for hovers and definitions. Files required to produce results should be already fetched and parsed while processing main file and its refs and imports. `ProjectManager::syncConfiguration` leads to parsing the whole workpace and required for references and workspace symbols only
- processing triple slash refs when collecting dependents, partially addresses sourcegraph/sourcegraph#2201
- do not throw an error when we were unable to fetch file from VFS
- added debug facilities
- fetching all TypeScript library files from local file system. Addresses sourcegraph/sourcegraph#2127 and sourcegraph/sourcegraph#2249

@beyang It's unclear why do we limit depth to 3 while fetching imports and dependencies? This particular issue provides a case when hover/definition information is not available because we haven't fetched all the required dependencies..