### PR TITLE
Definitions from TypeScript libraries

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -389,7 +389,7 @@ class InMemoryLanguageServiceHost implements ts.LanguageServiceHost {
         this.projectVersion = 1;
         this.files = [];
         // adding library files from the local file system
-        readTsLibraries().forEach((content, name) => {
+        getTypeScriptLibraries().forEach((content, name) => {
             this.fs.entries[name] = content;
         });
     }
@@ -662,7 +662,7 @@ var tsLibraries: Map<string, string>;
 /**
  * Fetches TypeScript library files from local file system
  */
-function readTsLibraries(): Map<string, string> {
+export function getTypeScriptLibraries(): Map<string, string> {
     if (!tsLibraries) {
         tsLibraries = new Map<string, string>();
         const path = path_.dirname(ts.getDefaultLibFilePath({ target: ts.ScriptTarget.ES2015 }));

--- a/src/test/language-server-test.ts
+++ b/src/test/language-server-test.ts
@@ -356,10 +356,11 @@ describe('LSP', function() {
                     'd.ts': 'export function bar() {}'
                 },
                 'deeprefs': {
-                    'a.ts': '/// <reference path="b.ts"/>\nfoo()\nbar()',
+                    'a.ts': '/// <reference path="b.ts"/>\nnamespace qux {\nlet f : foo;\n}',
                     'b.ts': '/// <reference path="c.ts"/>',
-                    'c.ts': '/// <reference path="d.ts"/>\nexport function foo() {}',
-                    'd.ts': 'export function bar() {}',
+                    'c.ts': '/// <reference path="d.ts"/>',
+                    'd.ts': '/// <reference path="e.ts"/>',
+                    'e.ts': 'namespace qux {\nexport interface foo {}\n}',
                 },
                 'missing': {
                     'a.ts': '/// <reference path="b.ts"/>\n/// <reference path="missing.ts"/>\nnamespace t {\n    function foo() : Bar {\n        return null;\n    }\n}',
@@ -435,7 +436,7 @@ describe('LSP', function() {
                     }
                 }, done);
         });
-        it('TODO deep definition', function(done: (err?: Error) => void) {
+        it('should resolve deep definitions', function(done: (err?: Error) => void) {
             // This test passes only because we expect no response from LSP server
             // for definition located in file references with depth 3 or more (a -> b -> c -> d (...))
             // This test will fail once we'll increase (or remove) depth limit
@@ -444,44 +445,22 @@ describe('LSP', function() {
                     uri: 'file:///deeprefs/a.ts'
                 },
                 position: {
-                    line: 1,
-                    character: 0
+                    line: 2,
+                    character: 8
                 }
             }, {
-                    uri: 'file:///deeprefs/c.ts',
+                    uri: 'file:///deeprefs/e.ts',
                     range: {
                         start: {
-                            line: 0,
+                            line: 1,
                             character: 0
                         },
                         end: {
-                            line: 0,
-                            character: 24
+                            line: 1,
+                            character: 23
                         }
                     }
-                }, () => {
-                    utils.definition({
-                        textDocument: {
-                            uri: 'file:///deeprefs/a.ts'
-                        },
-                        position: {
-                            line: 2,
-                            character: 0
-                        }
-                    }, null /*{
-                            uri: 'file:///deeprefs/d.ts',
-                            range: {
-                                start: {
-                                    line: 0,
-                                    character: 0
-                                },
-                                end: {
-                                    line: 0,
-                                    character: 24
-                                }
-                            }
-                        }*/, done);
-                });
+                }, done);
         });
         afterEach(function(done: () => void) {
             utils.tearDown(done);

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -151,7 +151,7 @@ export function definition(pos: vscode.TextDocumentPositionParams, expected: vsc
         }
     }).then((results: vscode.Location[]) => {
         check(done, () => {
-            chai.expect(results.length).to.equal(expected ? 1 : 0);
+            chai.expect(results.length).to.equal(expected ? 1 : 0, 'unexpected locations count');
             if (expected) {
                 const result = results[0];
                 chai.expect(result).to.deep.equal(expected);

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -140,7 +140,7 @@ function check(done: (err?: Error) => void, conditions: () => void) {
     }
 }
 
-export function definition(pos: vscode.TextDocumentPositionParams, expected: vscode.Location, done: (err?: Error) => void) {
+export function definition(pos: vscode.TextDocumentPositionParams, expected: vscode.Location | vscode.Location[], done: (err?: Error) => void) {
     channel.clientConnection.sendRequest(rt.DefinitionRequest.type, {
         textDocument: {
             uri: pos.textDocument.uri
@@ -150,12 +150,9 @@ export function definition(pos: vscode.TextDocumentPositionParams, expected: vsc
             character: pos.position.character
         }
     }).then((results: vscode.Location[]) => {
+        expected = expected ? Array.isArray(expected) ? expected : [expected] : null;
         check(done, () => {
-            chai.expect(results.length).to.equal(expected ? 1 : 0, 'unexpected locations count');
-            if (expected) {
-                const result = results[0];
-                chai.expect(result).to.deep.equal(expected);
-            }
+            chai.expect(results).to.deep.equal(expected);
         });
     }, (err?: Error) => {
         return done(err || new Error('definition request failed'))

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -248,7 +248,6 @@ export default class TypeScriptService {
                         if (!sourceFile) {
                             return resolve([]);
                         }
-
                         const offset: number = ts.getPositionOfLineAndCharacter(sourceFile, line, column);
                         const defs: ts.DefinitionInfo[] = configuration.service.getDefinitionAtPosition(fileName, offset);
                         const ret = [];
@@ -257,7 +256,7 @@ export default class TypeScriptService {
                                 const sourceFile = configuration.program.getSourceFile(def.fileName);
                                 const start = ts.getLineAndCharacterOfPosition(sourceFile, def.textSpan.start);
                                 const end = ts.getLineAndCharacterOfPosition(sourceFile, def.textSpan.start + def.textSpan.length);
-                                ret.push(Location.create(util.path2uri(this.root, def.fileName), {
+                                ret.push(Location.create(this.defUri(def.fileName), {
                                     start: start,
                                     end: end
                                 }));
@@ -526,13 +525,26 @@ export default class TypeScriptService {
     }
 
     /**
+     * Transforms definition's file name to URI. If definition belongs to TypeScript library,
+     * returns git://github.com/Microsoft/TypeScript URL, otherwise returns file:// one
+     */
+    private defUri(filePath: string): string {
+        filePath = util.normalizePath(filePath);
+        if (pm.getTypeScriptLibraries().has(filePath)) {
+            return 'git://github.com/Microsoft/TypeScript?master#lib/' + path_.basename(filePath);
+        }
+        return util.path2uri(this.root, filePath);
+    }
+
+    /**
      * Fetches up to limit navigation bar items from given project, flattennes them  
      */
     private getNavigationTreeItems(configuration: pm.ProjectConfiguration, limit?: number): SymbolInformation[] {
         const result = [];
-        const defaultLib = configuration.host.getDefaultLibFileName(configuration.host.getCompilationSettings());
+        const libraries = pm.getTypeScriptLibraries();
         for (const sourceFile of configuration.program.getSourceFiles()) {
-            if (sourceFile.fileName == defaultLib) {
+            // excluding navigation items from TypeScript libraries
+            if (libraries.has(util.normalizePath(sourceFile.fileName))) {
                 continue;
             }
             const tree = configuration.service.getNavigationTree(sourceFile.fileName);


### PR DESCRIPTION
- resolving TS library definitions to github.com/Microsoft/TypeScript#lib/..., addresses sourcegraph/sourcegraph#2248
- excluding symbols defined in TS libraries from workspace symbols
- fixed and enhanced tests

Tests are failing because they depend on #31