### PR TITLE
using TS version constant in TS library links

### DIFF
--- a/src/test/language-server-test.ts
+++ b/src/test/language-server-test.ts
@@ -5,6 +5,8 @@ import * as fs from 'fs';
 import * as mocha from 'mocha';
 import * as chai from 'chai';
 
+import * as ts from 'typescript';
+
 import * as vscode from 'vscode-languageserver';
 
 import Connection from '../connection';
@@ -531,7 +533,7 @@ describe('LSP', function () {
 					character: 16
 				}
 			}, [{
-				uri: 'git://github.com/Microsoft/TypeScript?v2.1.1#lib/lib.dom.d.ts',
+				uri: 'git://github.com/Microsoft/TypeScript?v' + ts.version + '#lib/lib.dom.d.ts',
 				range: {
 					start: {
 						line: 8750,
@@ -543,7 +545,7 @@ describe('LSP', function () {
 					}
 				}
 			}, {
-				uri: 'git://github.com/Microsoft/TypeScript?v2.1.1#lib/lib.dom.d.ts',
+				uri: 'git://github.com/Microsoft/TypeScript?v' + ts.version + '#lib/lib.dom.d.ts',
 				range: {
 					start: {
 						line: 8802,
@@ -567,7 +569,7 @@ describe('LSP', function () {
 						character: 50
 					}
 				}, {
-						uri: 'git://github.com/Microsoft/TypeScript?v2.1.1#lib/lib.es5.d.ts',
+						uri: 'git://github.com/Microsoft/TypeScript?v' + ts.version + '#lib/lib.es5.d.ts',
 						range: {
 							start: {
 								line: 24,

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -482,7 +482,7 @@ export default class TypeScriptService {
 	private defUri(filePath: string): string {
 		filePath = util.normalizePath(filePath);
 		if (pm.getTypeScriptLibraries().has(filePath)) {
-			return 'git://github.com/Microsoft/TypeScript?v2.1.1#lib/' + path_.basename(filePath);
+			return 'git://github.com/Microsoft/TypeScript?v' + ts.version + '#lib/' + path_.basename(filePath);
 		}
 		return util.path2uri(this.root, filePath);
 	}


### PR DESCRIPTION
- when forming links to TS library, using `ts.version` constant to keep links up to date with the TS version being used. Followup for sourcegraph/sourcegraph#2372 and @d8cf3b279b3826c88df1b2fe67131128197fc6aa

