### PR TITLE
Factor out LanguageHandler interface

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,5 +1,3 @@
-/// <reference path="../node_modules/vscode/thenable.d.ts"/>
-
 import {
 	IConnection,
 	createConnection,
@@ -27,170 +25,147 @@ import * as ts from 'typescript';
 import * as types from 'vscode-languageserver-types';
 
 import * as util from './util';
-import TypeScriptService from './typescript-service';
+import { LanguageHandler, TypeScriptService } from './typescript-service';
 
 import * as rt from './request-type';
 
-/**
- * Connection handles incoming requests and sends responses over the
- * JSONRPC connection. There is one Connection instance created for
- * each workspace. Connection also includes cached data from the
- * compiler that lets it respond more quickly. These caches are
- * deleted after the Connection is torn down.
- */
-export default class Connection {
+export default function NewConnection(input: any, output: any, strict: boolean, handler: LanguageHandler): IConnection {
+	const connection = createConnection(input, output);
 
-	connection: IConnection;
+	input.removeAllListeners('end');
+	input.removeAllListeners('close');
+	output.removeAllListeners('end');
+	output.removeAllListeners('close');
 
-	constructor(input: any, output: any, strict: boolean) {
-
-		this.connection = createConnection(input, output);
-
-		input.removeAllListeners('end');
-		input.removeAllListeners('close');
-		output.removeAllListeners('end');
-		output.removeAllListeners('close');
-
-		let workspaceRoot: string;
-		let closed = false;
-
-		function close() {
-			if (!closed) {
-				input.close();
-				output.close();
-				closed = true;
-			}
+	let closed = false;
+	function close() {
+		if (!closed) {
+			input.close();
+			output.close();
+			closed = true;
 		}
-		const service = new TypeScriptService();
-
-		this.connection.onRequest(rt.InitializeRequest.type, (params: InitializeParams): Promise<InitializeResult> => {
-			console.error('initialize', params.rootPath);
-			return service.initialize(params, this.connection, strict);
-		});
-
-		this.connection.onNotification(rt.ExitRequest.type, close);
-		this.connection.onRequest(rt.ShutdownRequest.type, () => []);
-
-		this.connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => service.didOpen(params));
-		this.connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => service.didChange(params));
-		this.connection.onDidSaveTextDocument((params: DidSaveTextDocumentParams) => service.didSave(params));
-		this.connection.onDidCloseTextDocument((params: DidCloseTextDocumentParams) => service.didClose(params));
-
-		this.connection.onRequest(rt.WorkspaceSymbolsRequest.type, (params: rt.WorkspaceSymbolParamsWithLimit): Promise<SymbolInformation[]> => {
-			const enter = new Date().getTime();
-			return new Promise<SymbolInformation[]>((resolve, reject) => {
-				const init = new Date().getTime();
-				try {
-					return service.getWorkspaceSymbols(params).then((result) => {
-						const exit = new Date().getTime();
-						console.error('workspace/symbol', params.query, 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
-						return resolve(result || []);
-					});
-				} catch (e) {
-					console.error(params, e);
-					return resolve([]);
-				}
-			});
-		});
-
-		this.connection.onRequest(rt.DocumentSymbolRequest.type, (params: DocumentSymbolParams): Promise<SymbolInformation[]> => {
-			const enter = new Date().getTime();
-			return new Promise<SymbolInformation[]>((resolve, reject) => {
-				const init = new Date().getTime();
-				try {
-					return service.getDocumentSymbol(params).then((result) => {
-						const exit = new Date().getTime();
-						console.error('textDocument/documentSymbol', "", 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
-						return resolve(result || []);
-					});
-				} catch (e) {
-					console.error(params, e);
-					return resolve([]);
-				}
-			});
-		});
-
-		this.connection.onRequest(rt.WorkspaceReferenceRequest.type, (params: rt.WorkspaceReferenceParams): Promise<rt.ReferenceInformation[]> => {
-			const enter = new Date().getTime();
-			return new Promise<rt.ReferenceInformation[]>((resolve, reject) => {
-				const init = new Date().getTime();
-				try {
-					return service.getWorkspaceReference(params).then((result) => {
-						const exit = new Date().getTime();
-						console.error('workspace/reference', 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
-						return resolve(result || []);
-					});
-				} catch (e) {
-					console.error(params, e);
-					return resolve([]);
-				}
-			});
-		});
-
-
-		this.connection.onDefinition((params: TextDocumentPositionParams): Promise<Definition> => {
-			const enter = new Date().getTime();
-			return new Promise<Definition>((resolve, reject) => {
-				try {
-					const init = new Date().getTime();
-					service.getDefinition(params).then((result) => {
-						const exit = new Date().getTime();
-						console.error('definition', params.textDocument.uri, params.position.line, params.position.character, 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
-						return resolve(result || []);
-					}, (e) => {
-						return reject(e);
-					});
-				} catch (e) {
-					console.error(params, e);
-					return resolve([]);
-				}
-			});
-		});
-
-		this.connection.onHover((params: TextDocumentPositionParams): Promise<Hover> => {
-			const enter = new Date().getTime();
-			return new Promise<Hover>((resolve, reject) => {
-				const init = new Date().getTime();
-				try {
-					service.getHover(params).then((hover) => {
-						const exit = new Date().getTime();
-						console.error('hover', params.textDocument.uri, params.position.line, params.position.character, 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
-						resolve(hover || { contents: [] });
-					}, (e) => {
-						return reject(e);
-					});
-				} catch (e) {
-					console.error(params, e);
-					resolve({ contents: [] });
-				}
-			});
-		});
-
-		this.connection.onReferences((params: ReferenceParams): Promise<Location[]> => {
-			return new Promise<Location[]>((resolve, reject) => {
-				const enter = new Date().getTime();
-				const init = new Date().getTime();
-				try {
-					service.getReferences(params).then((result) => {
-						const exit = new Date().getTime();
-						console.error('references', params.textDocument.uri, params.position.line, params.position.character, 'found', result.length, 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
-						return resolve(result || []);
-					}
-					);
-				} catch (e) {
-					console.error(params, e);
-					return resolve([]);
-				}
-			});
-		});
 	}
 
-	start() {
-		this.connection.listen();
-	}
+	connection.onRequest(rt.InitializeRequest.type, (params: InitializeParams): Promise<InitializeResult> => {
+		console.error('initialize', params.rootPath);
+		return handler.initialize(params, connection, strict);
+	});
 
-	// TODO(beyang): remove
-	sendRequest<P, R, E>(type: RequestType<P, R, E>, params?: P): Thenable<R> {
-		return this.connection.sendRequest(type, params);
-	}
+	connection.onNotification(rt.ExitRequest.type, close);
+	connection.onRequest(rt.ShutdownRequest.type, () => []);
+
+	connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => handler.didOpen(params));
+	connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => handler.didChange(params));
+	connection.onDidSaveTextDocument((params: DidSaveTextDocumentParams) => handler.didSave(params));
+	connection.onDidCloseTextDocument((params: DidCloseTextDocumentParams) => handler.didClose(params));
+
+	connection.onRequest(rt.WorkspaceSymbolsRequest.type, (params: rt.WorkspaceSymbolParamsWithLimit): Promise<SymbolInformation[]> => {
+		const enter = new Date().getTime();
+		return new Promise<SymbolInformation[]>((resolve, reject) => {
+			const init = new Date().getTime();
+			try {
+				return handler.getWorkspaceSymbols(params).then((result) => {
+					const exit = new Date().getTime();
+					console.error('workspace/symbol', params.query, 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
+					return resolve(result || []);
+				});
+			} catch (e) {
+				console.error(params, e);
+				return resolve([]);
+			}
+		});
+	});
+
+	connection.onRequest(rt.DocumentSymbolRequest.type, (params: DocumentSymbolParams): Promise<SymbolInformation[]> => {
+		const enter = new Date().getTime();
+		return new Promise<SymbolInformation[]>((resolve, reject) => {
+			const init = new Date().getTime();
+			try {
+				return handler.getDocumentSymbol(params).then((result) => {
+					const exit = new Date().getTime();
+					console.error('textDocument/documentSymbol', "", 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
+					return resolve(result || []);
+				});
+			} catch (e) {
+				console.error(params, e);
+				return resolve([]);
+			}
+		});
+	});
+
+	connection.onRequest(rt.WorkspaceReferenceRequest.type, (params: rt.WorkspaceReferenceParams): Promise<rt.ReferenceInformation[]> => {
+		const enter = new Date().getTime();
+		return new Promise<rt.ReferenceInformation[]>((resolve, reject) => {
+			const init = new Date().getTime();
+			try {
+				return handler.getWorkspaceReference(params).then((result) => {
+					const exit = new Date().getTime();
+					console.error('workspace/reference', 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
+					return resolve(result || []);
+				});
+			} catch (e) {
+				console.error(params, e);
+				return resolve([]);
+			}
+		});
+	});
+
+
+	connection.onDefinition((params: TextDocumentPositionParams): Promise<Definition> => {
+		const enter = new Date().getTime();
+		return new Promise<Definition>((resolve, reject) => {
+			try {
+				const init = new Date().getTime();
+				handler.getDefinition(params).then((result) => {
+					const exit = new Date().getTime();
+					console.error('definition', params.textDocument.uri, params.position.line, params.position.character, 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
+					return resolve(result || []);
+				}, (e) => {
+					return reject(e);
+				});
+			} catch (e) {
+				console.error(params, e);
+				return resolve([]);
+			}
+		});
+	});
+
+	connection.onHover((params: TextDocumentPositionParams): Promise<Hover> => {
+		const enter = new Date().getTime();
+		return new Promise<Hover>((resolve, reject) => {
+			const init = new Date().getTime();
+			try {
+				handler.getHover(params).then((hover) => {
+					const exit = new Date().getTime();
+					console.error('hover', params.textDocument.uri, params.position.line, params.position.character, 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
+					resolve(hover || { contents: [] });
+				}, (e) => {
+					return reject(e);
+				});
+			} catch (e) {
+				console.error(params, e);
+				resolve({ contents: [] });
+			}
+		});
+	});
+
+	connection.onReferences((params: ReferenceParams): Promise<Location[]> => {
+		return new Promise<Location[]>((resolve, reject) => {
+			const enter = new Date().getTime();
+			const init = new Date().getTime();
+			try {
+				handler.getReferences(params).then((result) => {
+					const exit = new Date().getTime();
+					console.error('references', params.textDocument.uri, params.position.line, params.position.character, 'found', result.length, 'total', (exit - enter) / 1000.0, 'busy', (exit - init) / 1000.0, 'wait', (init - enter) / 1000.0);
+					return resolve(result || []);
+				}
+				);
+			} catch (e) {
+				console.error(params, e);
+				return resolve([]);
+			}
+		});
+	});
+
+	return connection;
 }

--- a/src/language-server-stdio.ts
+++ b/src/language-server-stdio.ts
@@ -4,7 +4,8 @@ var os = require('os');
 
 var program = require('commander');
 
-import Connection from './connection';
+import NewConnection from './connection';
+import { TypeScriptService } from './typescript-service';
 import * as util from './util';
 
 process.on('uncaughtException', (err) => {
@@ -17,5 +18,5 @@ program
 	.parse(process.argv);
 
 util.setStrict(program.strict);
-let connection = new Connection(process.stdin, process.stdout, program.strict);
-connection.start();
+let connection = NewConnection(process.stdin, process.stdout, program.strict, new TypeScriptService());
+connection.listen();

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -1,10 +1,13 @@
+/// <reference path="../node_modules/vscode/thenable.d.ts" />
+
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as cluster from 'cluster';
 
-import Connection from './connection';
+import NewConnection from './connection';
+import { TypeScriptService } from './typescript-service';
 import * as util from './util';
 
 const program = require('commander');
@@ -42,8 +45,8 @@ if (cluster.isMaster) {
 } else {
 	console.error('Listening for incoming LSP connections on', lspPort);
 	var server = net.createServer((socket) => {
-		let connection = new Connection(socket, socket, program.strict);
-		connection.start();
+		let connection = NewConnection(socket, socket, program.strict, new TypeScriptService());
+		connection.listen();
 	});
 
 	server.listen(lspPort);

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -37,7 +37,7 @@ var sanitizeHtml = require('sanitize-html');
 var JSONPath = require('jsonpath-plus');
 
 
-/*
+/**
  * LanguageHandler handles LSP requests. It includes a handler method
  * for each LSP method that this language server supports. Each
  * handler method should be registered to the corresponding
@@ -57,8 +57,16 @@ export interface LanguageHandler {
 	didSave(params: DidSaveTextDocumentParams);
 }
 
-
-export default class TypeScriptService implements LanguageHandler {
+/**
+ * TypeScriptService handles incoming requests and return
+ * responses. There is a one-to-one-to-one correspondence between TCP
+ * connection, TypeScriptService instance, and language
+ * workspace. TypeScriptService caches data from the compiler across
+ * requests. The lifetime of the TypeScriptService instance is tied to
+ * the lifetime of the TCP connection, so its caches are deleted after
+ * the connection is torn down.
+ */
+export class TypeScriptService implements LanguageHandler {
 
 	projectManager: pm.ProjectManager;
 	root: string;


### PR DESCRIPTION
This PR does not change any behavior. It removes the `Connection` type, because it was an unnecessary layer between `IConnection` and `TypeScriptService` and introduces a new interface, `LanguageHandler`, that can be implemented by other `TypeScriptService`-like things (e.g., a version of `TypeScriptService` that handles fetching external dependencies).