### PR TITLE
Refactoring to enable language server to be used by buildserver

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -47,8 +47,11 @@ export function newConnection(input: any, output: any): IConnection {
 		}
 	}
 
+	// We attach one notification handler on `exit` here to handle the
+	// teardown of the connection.  If other handlers want to do
+	// something on connection destruction, they should register a
+	// handler on `shutdown`.
 	connection.onNotification(rt.ExitRequest.type, close);
-	connection.onRequest(rt.ShutdownRequest.type, () => []);
 
 	return connection;
 }
@@ -70,6 +73,7 @@ export function registerLanguageHandler(connection: IConnection, strict: boolean
 		}
 	});
 
+	connection.onShutdown(handler.shutdown);
 
 	connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => handler.didOpen(params));
 	connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => handler.didChange(params));

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -27,12 +27,12 @@ import * as types from 'vscode-languageserver-types';
 import * as util from './util';
 import { TypeScriptService } from './typescript-service';
 import { LanguageHandler } from './lang-handler';
+import * as fs from './fs';
 
 import * as rt from './request-type';
 
-export function newConnectionWithLangHandler(input: any, output: any, strict: boolean, handler: LanguageHandler): IConnection {
+export function newConnection(input: any, output: any): IConnection {
 	const connection = createConnection(input, output);
-
 	input.removeAllListeners('end');
 	input.removeAllListeners('close');
 	output.removeAllListeners('end');
@@ -47,18 +47,29 @@ export function newConnectionWithLangHandler(input: any, output: any, strict: bo
 		}
 	}
 
+	connection.onNotification(rt.ExitRequest.type, close);
+	connection.onRequest(rt.ShutdownRequest.type, () => []);
+
+	return connection;
+}
+
+export function registerLanguageHandler(connection: IConnection, strict: boolean, handler: LanguageHandler): void {
 	connection.onRequest(rt.InitializeRequest.type, (params: InitializeParams): Promise<InitializeResult> => {
 		console.error('initialize', params.rootPath);
+		let remoteFs: fs.FileSystem;
+		if (strict) {
+			remoteFs = new fs.RemoteFileSystem(connection);
+		} else {
+			remoteFs = new fs.LocalFileSystem(util.uri2path(params.rootPath));
+		}
 		try {
-			return handler.initialize(params, connection, strict);
+			return handler.initialize(params, remoteFs, strict);
 		} catch (e) {
 			console.error(params, e);
 			return Promise.reject(e);
 		}
 	});
 
-	connection.onNotification(rt.ExitRequest.type, close);
-	connection.onRequest(rt.ShutdownRequest.type, () => []);
 
 	connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => handler.didOpen(params));
 	connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => handler.didChange(params));
@@ -172,6 +183,4 @@ export function newConnectionWithLangHandler(input: any, output: any, strict: bo
 			}
 		});
 	});
-
-	return connection;
 }

--- a/src/lang-handler.ts
+++ b/src/lang-handler.ts
@@ -22,6 +22,8 @@ import {
 	DidSaveTextDocumentParams
 } from 'vscode-languageserver';
 
+import { FileSystem } from './fs';
+
 import * as rt from './request-type';
 
 /**
@@ -31,7 +33,7 @@ import * as rt from './request-type';
  * registration method on IConnection.
  */
 export interface LanguageHandler {
-	initialize(params: InitializeParams, connection: IConnection, strict: boolean): Promise<InitializeResult>;
+	initialize(params: InitializeParams, remoteFs: FileSystem, strict: boolean): Promise<InitializeResult>;
 	getDefinition(params: TextDocumentPositionParams): Promise<Location[]>;
 	getHover(params: TextDocumentPositionParams): Promise<Hover>;
 	getReferences(params: ReferenceParams): Promise<Location[]>;

--- a/src/lang-handler.ts
+++ b/src/lang-handler.ts
@@ -34,6 +34,7 @@ import * as rt from './request-type';
  */
 export interface LanguageHandler {
 	initialize(params: InitializeParams, remoteFs: FileSystem, strict: boolean): Promise<InitializeResult>;
+	shutdown(): Promise<void>;
 	getDefinition(params: TextDocumentPositionParams): Promise<Location[]>;
 	getHover(params: TextDocumentPositionParams): Promise<Hover>;
 	getReferences(params: ReferenceParams): Promise<Location[]>;

--- a/src/language-server-stdio.ts
+++ b/src/language-server-stdio.ts
@@ -4,7 +4,7 @@ var os = require('os');
 
 var program = require('commander');
 
-import { newConnectionWithLangHandler } from './connection';
+import { newConnection, registerLanguageHandler } from './connection';
 import { TypeScriptService } from './typescript-service';
 import * as util from './util';
 
@@ -18,5 +18,6 @@ program
 	.parse(process.argv);
 
 util.setStrict(program.strict);
-let connection = newConnectionWithLangHandler(process.stdin, process.stdout, program.strict, new TypeScriptService());
+const connection = newConnection(process.stdin, process.stdout);
+registerLanguageHandler(connection, program.strict, new TypeScriptService());
 connection.listen();

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as cluster from 'cluster';
 
-import { newConnectionWithLangHandler } from './connection';
+import { newConnection, registerLanguageHandler } from './connection';
 import { TypeScriptService } from './typescript-service';
 import * as util from './util';
 
@@ -45,7 +45,8 @@ if (cluster.isMaster) {
 } else {
 	console.error('Listening for incoming LSP connections on', lspPort);
 	var server = net.createServer((socket) => {
-		let connection = newConnectionWithLangHandler(socket, socket, program.strict, new TypeScriptService());
+		const connection = newConnection(socket, socket);
+		registerLanguageHandler(connection, program.strict, new TypeScriptService());
 		connection.listen();
 	});
 

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -68,15 +68,15 @@ export class ProjectManager {
 	/**
 	 * Ensures that all files are added (and parsed) to the project to which fileName belongs. 
 	 */
-	syncConfigurationFor(fileName: string, connection: IConnection) {
-		return this.syncConfiguration(this.getConfiguration(fileName), connection);
+	syncConfigurationFor(fileName: string) {
+		return this.syncConfiguration(this.getConfiguration(fileName));
 	}
 
 	/**
 	 * Ensures that all files are added (and parsed) for the given project.
 	 * Uses tsconfig.json settings to identify what files make a project (root files)
 	 */
-	syncConfiguration(config: ProjectConfiguration, connection: IConnection) {
+	syncConfiguration(config: ProjectConfiguration) {
 		if (config.host.complete) {
 			return;
 		}
@@ -252,25 +252,25 @@ export class ProjectManager {
 		return this.configs.get('');
 	}
 
-	didOpen(fileName: string, text: string, connection: IConnection) {
-		this.didChange(fileName, text, connection);
+	didOpen(fileName: string, text: string) {
+		this.didChange(fileName, text);
 	}
 
-	didClose(fileName: string, connection: IConnection) {
+	didClose(fileName: string) {
 		this.localFs.didClose(fileName);
 		let version = this.versions.get(fileName) || 0;
 		this.versions.set(fileName, ++version);
-		this.getConfiguration(fileName).prepare(null).then((config) => {
+		this.getConfiguration(fileName).prepare().then((config) => {
 			config.host.incProjectVersion();
 			config.program = config.service.getProgram();
 		});
 	}
 
-	didChange(fileName: string, text: string, connection: IConnection) {
+	didChange(fileName: string, text: string) {
 		this.localFs.didChange(fileName, text);
 		let version = this.versions.get(fileName) || 0;
 		this.versions.set(fileName, ++version);
-		this.getConfiguration(fileName).prepare(null).then((config) => {
+		this.getConfiguration(fileName).prepare().then((config) => {
 			config.host.incProjectVersion();
 			config.program = config.service.getProgram();
 		});
@@ -632,7 +632,7 @@ export class ProjectConfiguration {
 		return this.fs;
 	}
 
-	prepare(connection: IConnection): Promise<ProjectConfiguration> {
+	prepare(): Promise<ProjectConfiguration> {
 		if (!this.promise) {
 			this.promise = new Promise<ProjectConfiguration>((resolve, reject) => {
 				let configObject;

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -19,8 +19,6 @@ import * as match from './match-files';
 export class ProjectManager {
 
 	private root: string;
-	private strict: boolean;
-
 	private configs: Map<string, ProjectConfiguration>;
 
 	private remoteFs: FileSystem.FileSystem;
@@ -34,19 +32,19 @@ export class ProjectManager {
      */
 	private fetched: Set<string>;
 
-	constructor(root: string, strict: boolean, connection: IConnection) {
+	constructor(root: string, remoteFs: FileSystem.FileSystem) {
 		this.root = util.normalizePath(root);
-		this.strict = strict;
 		this.configs = new Map<string, ProjectConfiguration>();
 		this.localFs = new InMemoryFileSystem(this.root);
 		this.versions = new Map<string, number>();
 		this.fetched = new Set<string>();
+		this.remoteFs = remoteFs;
 
-		if (strict) {
-			this.remoteFs = new FileSystem.RemoteFileSystem(connection)
-		} else {
-			this.remoteFs = new FileSystem.LocalFileSystem(root)
-		}
+		// if (strict) {
+		// 	this.remoteFs = new FileSystem.RemoteFileSystem(connection)
+		// } else {
+		// 	this.remoteFs = new FileSystem.LocalFileSystem(root)
+		// }
 	}
 
 	getRemoteRoot(): string {

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -7,7 +7,7 @@ import * as chai from 'chai';
 
 import * as vscode from 'vscode-languageserver';
 
-import { newConnectionWithLangHandler } from '../connection';
+import { newConnection, registerLanguageHandler } from '../connection';
 import { TypeScriptService } from '../typescript-service';
 import { FileInfo } from '../fs';
 import * as rt from '../request-type';
@@ -57,12 +57,14 @@ export function setUp(memfs: any, done: (err?: Error) => void) {
 
 	channel.server = net.createServer((stream) => {
 		channel.serverIn = stream;
-		channel.serverConnection = newConnectionWithLangHandler(channel.serverIn, channel.serverOut, true, new TypeScriptService());
+		channel.serverConnection = newConnection(channel.serverIn, channel.serverOut);
+		registerLanguageHandler(channel.serverConnection, true, new TypeScriptService());
 		maybeDone();
 	});
 	channel.client = net.createServer((stream) => {
 		channel.clientIn = stream;
-		channel.clientConnection = newConnectionWithLangHandler(channel.clientIn, channel.clientOut, true, new TypeScriptService());
+		channel.clientConnection = newConnection(channel.clientIn, channel.clientOut);
+		registerLanguageHandler(channel.clientConnection, true, new TypeScriptService());
 		initFs(channel.clientConnection, memfs);
 		maybeDone();
 	});

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -124,7 +124,7 @@ export class TypeScriptService implements LanguageHandler {
 			promise = promise.then(() => {
 				const importFiles = new Set<string>();
 				return Promise.all(fileNames.map((fileName) => {
-					return this.projectManager.getConfiguration(fileName).prepare(this.connection).then((config) => {
+					return this.projectManager.getConfiguration(fileName).prepare().then((config) => {
 						const contents = this.projectManager.getFs().readFile(fileName) || '';
 						const info = ts.preProcessFile(contents, true, true);
 						const compilerOpt = config.host.getCompilationSettings();
@@ -243,7 +243,7 @@ export class TypeScriptService implements LanguageHandler {
 			const fileName: string = util.uri2path(uri);
 			try {
 				const configuration = this.projectManager.getConfiguration(fileName);
-				configuration.prepare(this.connection).then((configuration) => {
+				configuration.prepare().then((configuration) => {
 					try {
 						const sourceFile = this.getSourceFile(configuration, fileName);
 						if (!sourceFile) {
@@ -285,7 +285,7 @@ export class TypeScriptService implements LanguageHandler {
 			const fileName: string = util.uri2path(uri);
 			try {
 				const configuration = this.projectManager.getConfiguration(fileName);
-				configuration.prepare(this.connection).then(() => {
+				configuration.prepare().then(() => {
 					try {
 						const sourceFile = this.getSourceFile(configuration, fileName);
 						if (!sourceFile) {
@@ -330,7 +330,7 @@ export class TypeScriptService implements LanguageHandler {
 			const fileName: string = util.uri2path(uri);
 			try {
 				const configuration = this.projectManager.getConfiguration(fileName);
-				configuration.prepare(this.connection).then(() => {
+				configuration.prepare().then(() => {
 					try {
 						const sourceFile = this.getSourceFile(configuration, fileName);
 						if (!sourceFile) {
@@ -339,7 +339,7 @@ export class TypeScriptService implements LanguageHandler {
 
 						const started = new Date().getTime();
 
-						this.projectManager.syncConfigurationFor(fileName, this.connection);
+						this.projectManager.syncConfigurationFor(fileName);
 
 						const prepared = new Date().getTime();
 
@@ -409,7 +409,7 @@ export class TypeScriptService implements LanguageHandler {
 			const fileName = util.uri2path(uri);
 
 			const config = this.projectManager.getConfiguration(uri);
-			return config.prepare(this.connection).then(() => {
+			return config.prepare().then(() => {
 				const sourceFile = this.getSourceFile(config, fileName);
 				const tree = config.service.getNavigationTree(fileName);
 				const result: SymbolInformation[] = [];
@@ -423,8 +423,8 @@ export class TypeScriptService implements LanguageHandler {
 		const refInfo: rt.ReferenceInformation[] = [];
 		return this.ensureFilesForWorkspaceSymbol().then(() => {
 			return Promise.all(this.projectManager.getConfigurations().map((config) => {
-				return config.prepare(this.connection).then((config) => {
-					this.projectManager.syncConfiguration(config, this.connection);
+				return config.prepare().then((config) => {
+					this.projectManager.syncConfiguration(config);
 					for (let source of config.service.getProgram().getSourceFiles().sort((a, b) => a.fileName.localeCompare(b.fileName))) {
 						if (util.normalizePath(source.fileName).indexOf(`${path_.posix.sep}node_modules${path_.posix.sep}`) !== -1) {
 							continue;
@@ -1245,7 +1245,7 @@ export class TypeScriptService implements LanguageHandler {
 	didOpen(params: DidOpenTextDocumentParams) {
 		const uri = util.uri2reluri(params.textDocument.uri, this.root);
 		return this.ensureFilesForHoverAndDefinition(uri).then(() => {
-			this.projectManager.didOpen(util.uri2path(uri), params.textDocument.text, this.connection);
+			this.projectManager.didOpen(util.uri2path(uri), params.textDocument.text);
 		});
 	}
 
@@ -1261,7 +1261,7 @@ export class TypeScriptService implements LanguageHandler {
 		if (!text) {
 			return;
 		}
-		this.projectManager.didChange(util.uri2path(uri), text, this.connection);
+		this.projectManager.didChange(util.uri2path(uri), text);
 	}
 
 	didSave(params: DidSaveTextDocumentParams) {
@@ -1274,7 +1274,7 @@ export class TypeScriptService implements LanguageHandler {
 	didClose(params: DidCloseTextDocumentParams) {
 		const uri = util.uri2reluri(params.textDocument.uri, this.root);
 		return this.ensureFilesForHoverAndDefinition(uri).then(() => {
-			this.projectManager.didClose(util.uri2path(uri), this.connection);
+			this.projectManager.didClose(util.uri2path(uri));
 		});
 	}
 
@@ -1355,9 +1355,9 @@ export class TypeScriptService implements LanguageHandler {
 			this.collectWorkspaceSymbols(query, limit, configurations, index + 1, items, callback);
 		};
 
-		configuration.prepare(this.connection).then(() => {
+		configuration.prepare().then(() => {
 			setImmediate(() => {
-				this.projectManager.syncConfiguration(configuration, this.connection);
+				this.projectManager.syncConfiguration(configuration);
 				const chunkSize = limit ? Math.min(limit, limit - items.length) : undefined;
 				setImmediate(() => {
 					if (query) {

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -83,6 +83,8 @@ export class TypeScriptService implements LanguageHandler {
 		return this.initialized;
 	}
 
+	shutdown(): Promise<void> { return Promise.resolve(); }
+
 	private ensuredFilesForHoverAndDefinition = new Map<string, Promise<void>>();
 
 	private ensureFilesForHoverAndDefinition(uri: string): Promise<void> {

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -52,24 +52,19 @@ export class TypeScriptService implements LanguageHandler {
 	projectManager: pm.ProjectManager;
 	root: string;
 
-	private connection: IConnection;
-
-	private emptyQueryWorkspaceSymbols: Promise<SymbolInformation[]>; // cached response for empty workspace/symbol query
-
 	private strict: boolean;
-
+	private emptyQueryWorkspaceSymbols: Promise<SymbolInformation[]>; // cached response for empty workspace/symbol query
 	private initialized: Promise<InitializeResult>;
 
-	initialize(params: InitializeParams, connection: IConnection, strict: boolean): Promise<InitializeResult> {
+	initialize(params: InitializeParams, remoteFs: FileSystem.FileSystem, strict: boolean): Promise<InitializeResult> {
 		if (this.initialized) {
 			return this.initialized;
 		}
 		this.initialized = new Promise<InitializeResult>((resolve) => {
 			if (params.rootPath) {
 				this.root = util.uri2path(params.rootPath);
-				this.connection = connection;
 				this.strict = strict;
-				this.projectManager = new pm.ProjectManager(this.root, strict, connection);
+				this.projectManager = new pm.ProjectManager(this.root, remoteFs);
 
 				this.ensureFilesForWorkspaceSymbol(); // pre-fetching
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 
     "compilerOptions": {
-        "target": "ES5",
+        "target": "ES6",
         "lib": ["es2016"],
         "types": ["node", "mocha", "chai"],
         "module": "commonjs",


### PR DESCRIPTION
This should involve no change in behavior, but it moves references to `IConnection` out of the language handler level. The only way that the language handler was using the connection was to issue LSP-VFS queries, which the build server will want to intercept. This change creates the remote FS outside of the language handler and then passes the remote FS to the language handler in the `initialize` method.