### PR TITLE
Make it work in VSCode/Windows

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -114,12 +114,7 @@ export class ProjectManager {
 	 * change.
 	 */
 	async refreshModuleStructureAt(root: string): Promise<void> {
-		if (!root.startsWith('/')) {
-			root = '/' + root;
-		}
-		if (root !== '/' && root.endsWith('/')) {
-			root = root.substring(0, root.length - 1);
-		}
+		root = util.normalizeDir(root);
 		const filesToFetch: string[] = [];
 		await this.walkRemote(root, (path: string, info: FileSystem.FileInfo, err?: Error): (Error | null) => {
 			if (err) {
@@ -146,12 +141,7 @@ export class ProjectManager {
 
 		// require re-parsing of projects whose file set may have been affected
 		for (let [dir, config] of this.configs) {
-			if (!dir.startsWith('/')) {
-				dir = '/' + dir;
-			}
-			if (dir !== '/' && dir.endsWith('/')) {
-				dir = dir.substring(0, dir.length - 1);
-			}
+			dir = util.normalizeDir(dir);
 
 			if (dir.startsWith(root + '/') || root.startsWith(dir + '/') || root === dir) {
 				config.reset();

--- a/src/util.ts
+++ b/src/util.ts
@@ -164,3 +164,26 @@ export function isDependencyFile(filename: string): boolean {
 export function isDeclarationFile(filename: string): boolean {
 	return filename.endsWith(".d.ts");
 }
+
+/**
+ * Converts filename to POSIX-style absolute one if filename does not denote absolute path already
+ */
+export function absolutize(filename: string) {
+	filename = normalizePath(filename);
+	// If POSIX path does not treats filename as absolute, let's try system-specific one
+	if (!path.posix.isAbsolute(filename) && !path.isAbsolute(filename)) {
+		filename = '/' + filename;
+	}
+	return filename;
+}
+
+/**
+ * Absolutizes directory name and cuts trailing slashes
+ */
+export function normalizeDir(dir: string) {
+	dir = absolutize(dir);
+	if (dir !== '/') {
+		dir = dir.replace(/[\/]+$/, '');
+	}
+	return dir;
+}


### PR DESCRIPTION
- Taking into account possibility that we are running on Windows where absolute path does not start with "/". This PR overrides accidentally closed #41 (my bad, sorry)