### PR TITLE
simplified log messages

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -76,7 +76,7 @@ export function registerLanguageHandler(connection: IConnection, strict: boolean
 		try {
 			const result = await handler.getWorkspaceSymbols(params);
 			const exit = new Date().getTime();
-			console.error('workspace/symbol', params.query, 'total', (exit - enter) / 1000.0, 'busy', (exit - enter) / 1000.0);
+			console.error('workspace/symbol', params.query, (exit - enter) / 1000.0);
 			return Promise.resolve(result || []);
 		} catch (e) {
 			console.error(params, e);
@@ -89,7 +89,7 @@ export function registerLanguageHandler(connection: IConnection, strict: boolean
 		try {
 			const result = await handler.getDocumentSymbol(params);
 			const exit = new Date().getTime();
-			console.error('textDocument/documentSymbol', 'total', (exit - enter) / 1000.0, 'busy', (exit - enter) / 1000.0);
+			console.error('textDocument/documentSymbol', params.textDocument.uri, (exit - enter) / 1000.0);
 			return Promise.resolve(result || []);
 		} catch (e) {
 			console.error(params, e);
@@ -102,7 +102,7 @@ export function registerLanguageHandler(connection: IConnection, strict: boolean
 		try {
 			const result = await handler.getWorkspaceReference(params);
 			const exit = new Date().getTime();
-			console.error('workspace/reference', 'total', (exit - enter) / 1000.0, 'busy', (exit - enter) / 1000.0);
+			console.error('workspace/reference', (exit - enter) / 1000.0);
 			return Promise.resolve(result || []);
 		} catch (e) {
 			console.error(params, e);
@@ -115,7 +115,7 @@ export function registerLanguageHandler(connection: IConnection, strict: boolean
 		try {
 			const result = await handler.getDefinition(params);
 			const exit = new Date().getTime();
-			console.error('definition', params.textDocument.uri, params.position.line, params.position.character, 'total', (exit - enter) / 1000.0, 'busy', (exit - enter) / 1000.0);
+			console.error('definition', docid(params), (exit - enter) / 1000.0);
 			return Promise.resolve(result || []);
 		} catch (e) {
 			console.error(params, e);
@@ -128,7 +128,7 @@ export function registerLanguageHandler(connection: IConnection, strict: boolean
 		try {
 			const result = await handler.getHover(params);
 			const exit = new Date().getTime();
-			console.error('hover', params.textDocument.uri, params.position.line, params.position.character, 'total', (exit - enter) / 1000.0, 'busy', (exit - enter) / 1000.0);
+			console.error('hover', docid(params), (exit - enter) / 1000.0);
 			return Promise.resolve(result || { contents: [] });
 		} catch (e) {
 			console.error(params, e);
@@ -141,11 +141,15 @@ export function registerLanguageHandler(connection: IConnection, strict: boolean
 		try {
 			const result = await handler.getReferences(params);
 			const exit = new Date().getTime();
-			console.error('references', params.textDocument.uri, params.position.line, params.position.character, 'found', result.length, 'total', (exit - enter) / 1000.0, 'busy', (exit - enter) / 1000.0);
+			console.error('references', docid(params), 'found', result.length, (exit - enter) / 1000.0);
 			return Promise.resolve(result || []);
 		} catch (e) {
 			console.error(params, e);
 			return Promise.reject(e);
 		}
 	});
+}
+
+function docid(params: TextDocumentPositionParams): string {
+	return params.textDocument.uri + ':' + params.position.line + ':' + params.position.character;
 }


### PR DESCRIPTION
Displaying requests in form `op args time`; for document-position-like arguments displaying them as `url:line:column`.
Sample: `[wkr1] hover file:///d%3A/exp/angular/tools/typings-test/include-all.ts:24:4 0.014`