### PR TITLE
handle promise rejections

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -64,12 +64,35 @@ export function registerLanguageHandler(connection: IConnection, strict: boolean
 		}
 	});
 
-	connection.onShutdown(() => handler.shutdown());
+	connection.onShutdown(() => {
+		handler.shutdown().catch((e) => {
+			console.error("shutdown failed:", e);
+		});
+	});
 
-	connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => handler.didOpen(params));
-	connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => handler.didChange(params));
-	connection.onDidSaveTextDocument((params: DidSaveTextDocumentParams) => handler.didSave(params));
-	connection.onDidCloseTextDocument((params: DidCloseTextDocumentParams) => handler.didClose(params));
+	connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => {
+		handler.didOpen(params).catch((e) => {
+			console.error("textDocument/didOpen failed:", e);
+		});
+	});
+
+	connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => {
+		handler.didChange(params).catch((e) => {
+			console.error("textDocument/didChange failed:", e);
+		});
+	});
+
+	connection.onDidSaveTextDocument((params: DidSaveTextDocumentParams) => {
+		handler.didSave(params).catch((e) => {
+			console.error("textDocument/didSave failed:", e);
+		});
+	});
+
+	connection.onDidCloseTextDocument((params: DidCloseTextDocumentParams) => {
+		handler.didClose(params).catch((e) => {
+			console.error("textDocument/didClose failed:", e);
+		});
+	});
 
 	connection.onRequest(rt.WorkspaceSymbolsRequest.type, async (params: rt.WorkspaceSymbolParamsWithLimit): Promise<SymbolInformation[]> => {
 		const enter = new Date().getTime();


### PR DESCRIPTION
Handle promise rejections at the top level, so we don't get errors of the form

```
UnhandledPromiseRejectionWarning: Unhandled promise rejection (reje
ction id: 1): Error: ENOENT: no such file or directory, scandir 'd:\d:\exp\tslin
t'
(node:11268) DeprecationWarning: Unhandled promise rejections are deprecated. In
 the future, promise rejections that are not handled will terminate the Node.js
process with a non-zero exit code.
```