### PR TITLE
Polishing command line options processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Run `yarn test`.
 ## Command line arguments 
 
 * `-p, --port` specifies port to use, default one is `2089`
-* `-s, --strict` enables strict mode where server expects all files to be receives in `didOpen` notification requests.
+* `-s, --strict` enables strict mode where server expects all files to be receives in `didOpen` notification requests
+* `-c, --cluster` specifies number of concurrent cluster workers (defaults to number of CPUs)
+* `-t, --trace` enables printing of all incoming and outgoing messages
+* `-l, --logfile` specifies additional log file to print all messages to
 
 ## Supported LSP requests
 

--- a/lib/language-server-stdio.js
+++ b/lib/language-server-stdio.js
@@ -3,15 +3,16 @@
 const connection_1 = require("./connection");
 const typescript_service_1 = require("./typescript-service");
 const util = require("./util");
+const packageJson = require('../package.json');
 var program = require('commander');
 process.on('uncaughtException', (err) => {
     console.error(err);
 });
 program
-    .version('0.0.1')
-    .option('-s, --strict', 'Strict mode')
-    .option('-t, --trace', 'Print all requests and responses')
-    .option('-l, --logfile [file]', 'Also log to this file (in addition to stderr')
+    .version(packageJson.version)
+    .option('-s, --strict', 'enables strict mode')
+    .option('-t, --trace', 'print all requests and responses')
+    .option('-l, --logfile [file]', 'also log to this file (in addition to stderr)')
     .parse(process.argv);
 util.setStrict(program.strict);
 const connection = connection_1.newConnection(process.stdin, process.stdout, { trace: program.trace, logfile: program.logfile });

--- a/lib/language-server.js
+++ b/lib/language-server.js
@@ -4,18 +4,19 @@ const typescript_service_1 = require("./typescript-service");
 const server = require("./server");
 const util = require("./util");
 const program = require('commander');
+const packageJson = require('../package.json');
 const defaultLspPort = 2089;
 const numCPUs = require('os').cpus().length;
 process.on('uncaughtException', (err) => {
     console.error(err);
 });
 program
-    .version('0.0.1')
-    .option('-s, --strict', 'Strict mode')
-    .option('-p, --port [port]', 'LSP port (' + defaultLspPort + ')', parseInt)
-    .option('-c, --cluster [num]', 'Number of concurrent cluster workers (defaults to number of CPUs, ' + numCPUs + ')', parseInt)
-    .option('-t, --trace', 'Print all requests and responses')
-    .option('-l, --logfile [file]', 'Also log to this file (in addition to stderr')
+    .version(packageJson.version)
+    .option('-s, --strict', 'enabled strict mode')
+    .option('-p, --port [port]', 'specifies LSP port to use (' + defaultLspPort + ')', parseInt)
+    .option('-c, --cluster [num]', 'number of concurrent cluster workers (defaults to number of CPUs, ' + numCPUs + ')', parseInt)
+    .option('-t, --trace', 'print all requests and responses')
+    .option('-l, --logfile [file]', 'also log to this file (in addition to stderr)')
     .parse(process.argv);
 util.setStrict(program.strict);
 const lspPort = program.port || defaultLspPort;

--- a/src/language-server-stdio.ts
+++ b/src/language-server-stdio.ts
@@ -4,6 +4,7 @@ import { newConnection, registerLanguageHandler } from './connection';
 import { TypeScriptService } from './typescript-service';
 import * as util from './util';
 
+const packageJson = require('../package.json');
 var program = require('commander');
 
 process.on('uncaughtException', (err: string) => {
@@ -11,10 +12,10 @@ process.on('uncaughtException', (err: string) => {
 });
 
 program
-	.version('0.0.1')
-	.option('-s, --strict', 'Strict mode')
-	.option('-t, --trace', 'Print all requests and responses')
-	.option('-l, --logfile [file]', 'Also log to this file (in addition to stderr')
+	.version(packageJson.version)
+	.option('-s, --strict', 'enables strict mode')
+	.option('-t, --trace', 'print all requests and responses')
+	.option('-l, --logfile [file]', 'also log to this file (in addition to stderr)')
 	.parse(process.argv);
 
 util.setStrict(program.strict);

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -6,6 +6,7 @@ import { TypeScriptService } from './typescript-service';
 import * as server from './server';
 import * as util from './util';
 const program = require('commander');
+const packageJson = require('../package.json');
 
 const defaultLspPort = 2089;
 const numCPUs = require('os').cpus().length;
@@ -14,12 +15,12 @@ process.on('uncaughtException', (err: string) => {
 });
 
 program
-	.version('0.0.1')
-	.option('-s, --strict', 'Strict mode')
-	.option('-p, --port [port]', 'LSP port (' + defaultLspPort + ')', parseInt)
-	.option('-c, --cluster [num]', 'Number of concurrent cluster workers (defaults to number of CPUs, ' + numCPUs + ')', parseInt)
-	.option('-t, --trace', 'Print all requests and responses')
-	.option('-l, --logfile [file]', 'Also log to this file (in addition to stderr')
+	.version(packageJson.version)
+	.option('-s, --strict', 'enabled strict mode')
+	.option('-p, --port [port]', 'specifies LSP port to use (' + defaultLspPort + ')', parseInt)
+	.option('-c, --cluster [num]', 'number of concurrent cluster workers (defaults to number of CPUs, ' + numCPUs + ')', parseInt)
+	.option('-t, --trace', 'print all requests and responses')
+	.option('-l, --logfile [file]', 'also log to this file (in addition to stderr)')
 	.parse(process.argv);
 
 util.setStrict(program.strict);


### PR DESCRIPTION
- reading program version from `package.json` (addresses #54)
- updated `README.md` to include recently added options (`--trace`, `--logfile`)
- adjusted program options descriptions to match commander's ones (start with lowercase letter, no dot)