### PR TITLE
Taking into account `IncludeDeclaration` parameter

### DIFF
--- a/src/test/language-server-test.ts
+++ b/src/test/language-server-test.ts
@@ -396,7 +396,7 @@ export function testWithLangHandler(newLanguageHandler: () => LanguageHandler) {
 			after(function (done: () => void) {
 				utils.tearDown(done);
 			});
-			it('references', function (done: (err?: Error) => void) {
+			it('produces references with declaration', function (done: (err?: Error) => void) {
 				utils.references({
 					textDocument: {
 						uri: 'file:///a.js'
@@ -404,8 +404,25 @@ export function testWithLangHandler(newLanguageHandler: () => LanguageHandler) {
 					position: {
 						line: 0,
 						character: 20
+					},
+					context: {
+						includeDeclaration: true
 					}
 				}, 3, done);
+			});
+			it('produces references without declaration', function (done: (err?: Error) => void) {
+				utils.references({
+					textDocument: {
+						uri: 'file:///a.js'
+					},
+					position: {
+						line: 0,
+						character: 20
+					},
+					context: {
+						includeDeclaration: false
+					}
+				}, 2, done);
 			});
 		});
 		describe('workspace/symbol and textDocument/documentSymbol', function () {

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -202,19 +202,8 @@ export function hover(pos: vscode.TextDocumentPositionParams, expected: vscode.H
 	})
 }
 
-export function references(pos: vscode.TextDocumentPositionParams, expected: number, done: (err?: Error) => void) {
-	channel.clientConnection.sendRequest(rt.ReferencesRequest.type, {
-		textDocument: {
-			uri: pos.textDocument.uri,
-		},
-		position: {
-			line: pos.position.line,
-			character: pos.position.character
-		},
-		context: {
-			includeDeclaration: false,
-		}
-	}).then((result: vscode.Location[]) => {
+export function references(params: vscode.ReferenceParams, expected: number, done: (err?: Error) => void) {
+	channel.clientConnection.sendRequest(rt.ReferencesRequest.type, params).then((result: vscode.Location[]) => {
 		check(done, () => {
 			chai.expect(result.length).to.equal(expected);
 		});


### PR DESCRIPTION
- when searching for references, taking into account `IncludeDeclaration` parameter  to control if definition should be included. Addresses sourcegraph/sourcegraph#3101