### PR TITLE
Empty files are valid files too

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -573,11 +573,11 @@ export class InMemoryLanguageServiceHost implements ts.LanguageServiceHost {
 
 	getScriptSnapshot(fileName: string): ts.IScriptSnapshot {
 		let entry = this.fs.readFile(fileName);
-		if (!entry) {
+		if (entry === undefined) {
 			fileName = path_.posix.join(this.root, fileName);
 			entry = this.fs.readFile(fileName);
 		}
-		if (!entry) {
+		if (entry === undefined) {
 			return undefined;
 		}
 		return ts.ScriptSnapshot.fromString(entry);
@@ -592,11 +592,9 @@ export class InMemoryLanguageServiceHost implements ts.LanguageServiceHost {
 	}
 
 	trace(message: string) {
-		console.error(message);
 	}
 
 	log(message: string) {
-		console.error(message);
 	}
 
 	error(message: string) {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -643,7 +643,7 @@ export class InMemoryFileSystem implements ts.ParseConfigHost, ts.ModuleResoluti
 		return this.readFile(path) !== undefined;
 	}
 
-	readFile(path: string): string {
+	readFile(path: string): string | undefined {
 		let content = this.overlay[path];
 		if (content !== undefined) {
 			return content;

--- a/src/test/language-server-test.ts
+++ b/src/test/language-server-test.ts
@@ -1821,7 +1821,8 @@ let z : foo.`,
 					'reference.ts': `namespace foo { 
 	/** bar doc*/
 	export interface bar {}
-}`
+}`,
+					'empty.ts': ``
 				}, done);
 			});
 			after(function (done: () => void) {
@@ -1899,6 +1900,17 @@ let z : foo.`,
 					sortText: '0',
 					detail: 'interface foo.bar'
 				}], done);
+			});
+			it('produces completions for empty files', function (done: (err?: Error) => void) {
+				utils.completions({
+					textDocument: {
+						uri: 'file:///empty.ts'
+					},
+					position: {
+						line: 0,
+						character: 0
+					}
+				}, null, done);
 			});
 		});
 	});

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -297,8 +297,13 @@ export function completions(params: vscode.TextDocumentPositionParams, expected:
 	channel.clientConnection.sendRequest(rt.TextDocumentCompletionRequest.type, params).then((result: vscode.CompletionList) => {
 		check(done, () => {
 			chai.assert(result);
+			chai.assert(result.items);
 			result.items.sort(cmp);
-			chai.expect(result.items).to.deep.equal(expected.sort(cmp));
+			if (expected) {
+				chai.expect(result.items).to.deep.equal(expected.sort(cmp));
+			} else {
+				chai.expect(result.items.length).to.not.equal(0);
+			}
 		});
 	}, (err?: Error) => {
 		return done(err || new Error('textDocument/completion request failed'))


### PR DESCRIPTION
- when FS read empty file it's OK, we should compare against `undefined` to determine if there is no such a file instead of casting content to boolean. Addresses #64
- made `LanguageServiceHost::log` and `LanguageServiceHost::trace` implementations empty, otherwise `completions` request may produce lot of useless output