### PR TITLE
e2e tests (WIP)

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,8 +6,13 @@ let path = require('path');
 
 process.chdir(path.dirname(__dirname));
 
+let filter = '';
+if (process.argv.length > 2) {
+	filter = '-g ' + process.argv[2];
+}
+
 try {
-	child_process.execSync(path.normalize('./node_modules/.bin/mocha') + ' -r ts-node/register src/test/**/*.ts', {stdio: 'inherit'});
+	child_process.execSync(path.normalize('./node_modules/.bin/mocha') + ' -r ts-node/register ' + filter + ' src/test/**/*.ts', {stdio: 'inherit'});
 } catch (e) {
 	process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     },
     "scripts": {
         "test": "node bin/test",
+        "test-e2e": "node bin/test e2e",
+        "test-lsp": "node bin/test LSP",
         "fmt-check": "node bin/fmt-check",
         "fmt": "node bin/fmt",
         "prepublish": "node bin/build",
@@ -51,8 +53,10 @@
     "devDependencies": {
         "@types/chai": "^3.4.34",
         "@types/mocha": "^2.2.32",
+        "@types/tmp": "^0.0.32",
         "chai": "^3.4.34",
         "mocha": "^2.2.32",
+        "tmp": "^0.0.31",
         "ts-node": "^1.6.1",
         "typescript-formatter": "^4.0.0"
     },

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -49,20 +49,23 @@ export class RemoteFileSystem implements FileSystem {
 export class LocalFileSystem implements FileSystem {
 
 	private root: string;
+	private resolver: (...segments: any[]) => string;
 
-	constructor(root: string) {
-		this.root = root
+
+	constructor(root: string, resolver: (...segments: any[]) => string = path_.resolve) {
+		this.root = root;
+		this.resolver = resolver;
 	}
 
 	readDir(path: string, callback: (err: Error | null, result?: FileInfo[]) => void): void {
-		path = path_.resolve(this.root, path);
+		path = this.resolver(this.root, path);
 		fs.readdir(path, (err: Error, files: string[]) => {
 			if (err) {
 				return callback(err)
 			}
 			let ret: FileInfo[] = [];
 			files.forEach((f) => {
-				const stats: fs.Stats = fs.statSync(path_.resolve(path, f));
+				const stats: fs.Stats = fs.statSync(this.resolver(path, f));
 				ret.push({
 					name: f,
 					size: stats.size,
@@ -74,13 +77,81 @@ export class LocalFileSystem implements FileSystem {
 	}
 
 	readFile(path: string, callback: (err: Error | null, result?: string) => void): void {
-		path = path_.resolve(this.root, path);
+		path = this.resolver(this.root, path);
 		fs.readFile(path, (err: Error, buf: Buffer) => {
 			if (err) {
 				return callback(err)
 			}
 			return callback(null, buf.toString())
 		});
+	}
+
+}
+
+export interface MemoryFileSystemNode {
+	[name: string]: string | MemoryFileSystemNode;
+}
+
+export class MemoryFileSystem implements FileSystem {
+
+	private memfs: MemoryFileSystemNode;
+
+	constructor(memfs: MemoryFileSystemNode) {
+		this.memfs = memfs;
+	}
+
+	readDir(path: string, callback: (err: Error | null, result?: FileInfo[]) => void): void {
+		path = path.replace(/^\//, '');
+		const components = path.length ? path.split('/') : [];
+		let node = this.memfs;
+		let i = 0;
+		while (i < components.length) {
+			const n = node[components[i]];
+			if (!n || typeof n == 'string') {
+				return callback(new Error('rd: no such file ' + path));
+			}
+			node = n as MemoryFileSystemNode;
+			i++;
+		}
+		const keys = Object.keys(node);
+		let result: FileInfo[] = []
+		keys.forEach((k) => {
+			const v = node[k];
+			if (typeof v == 'string') {
+				result.push({
+					name: k,
+					size: v.length,
+					dir: false
+				})
+			} else {
+				result.push({
+					name: k,
+					size: 0,
+					dir: true
+				});
+			}
+		});
+		return callback(null, result);
+	}
+
+	readFile(path: string, callback: (err: Error | null, result?: string) => void): void {
+		path = path.replace(/^\//, '');
+		const components = path.length ? path.split('/') : [];
+		let node = this.memfs;
+		let i = 0;
+		while (i < components.length - 1) {
+			const n = node[components[i]];
+			if (!n || typeof n == 'string') {
+				return callback(new Error('no such file ' + path));
+			}
+			node = n as MemoryFileSystemNode;
+			i++;
+		}
+		const content = node[components[components.length - 1]];
+		if (!content || typeof content != 'string') {
+			throw new Error('no such file ' + path);
+		}
+		return callback(null, content);
 	}
 
 }

--- a/src/test/language-server-test-e2e.ts
+++ b/src/test/language-server-test-e2e.ts
@@ -1,0 +1,726 @@
+import * as cp from 'child_process';
+import * as path_ from 'path';
+
+import * as tmp from 'tmp';
+
+import * as utils from './test-utils';
+import { LocalFileSystem } from '../fs';
+
+import { TypeScriptService } from '../typescript-service';
+
+// forcing strict mode
+import * as util from '../util';
+util.setStrict(true);
+
+
+function exec(command: string, cwd: string) {
+	const opts = {
+		cwd
+	};
+	console.log('executing:', command);
+	console.log(cp.execSync(command, opts).toString());
+}
+
+function clone(repo: string, hash: string, temp: string) {
+	exec('git clone --single-branch ' + repo + ' .', temp);
+	exec('git checkout ' + hash, temp);
+}
+
+function e2e(repo: string, hash: string, descriptor: utils.TestDescriptor) {
+	describe('e2e ' + repo, () => {
+
+		let cleanup: () => void = null;
+		let root: string = null;
+
+		before(function (done) {
+			this.timeout(0);
+			cleanup = null;
+			tmp.dir({ unsafeCleanup: true }, (err, path, callback) => {
+				if (err) {
+					return done(err);
+				}
+				console.log('using temporary directory', path);
+				cleanup = callback;
+				root = path;
+
+				try {
+					clone(repo, hash, path);
+				} catch (e) {
+					return done(e);
+				}
+				utils.setUp(new TypeScriptService(), new LocalFileSystem(root, path_.join), done);
+			});
+		});
+		describe('passes', () => {
+			utils.tests(descriptor);
+		});
+		after(function (done) {
+			this.timeout(0);
+			if (cleanup) {
+				cleanup();
+			}
+			utils.tearDown(done);
+		});
+	});
+}
+
+e2e('https://github.com/palantir/tslint', 'f53ec359b7d95795f1da58463b73fc4987bbf554', {
+	hovers: {
+		'src/utils.ts:52:20': {
+			contents: [
+				{
+					'language': 'typescript',
+					'value': 'function dedent(strings: TemplateStringsArray, ...values: string[]): string'
+				},
+				'Removes leading indents from a template string without removing all leading whitespace'
+			]
+		}
+	},
+	definitions: {
+		'src/configuration.ts:108:20': 'src/configuration.ts:129:0:155:1'
+	},
+	references: {
+		'src/utils.ts:45:20': 5
+	},
+	xdefinitions: {
+		'src/rules/arrayTypeRule.ts:31:43': [
+			{
+				'location': {
+					'range': {
+						'end': {
+							'character': 1,
+							'line': 69
+						},
+						'start': {
+							'character': 0,
+							'line': 52
+						}
+					},
+					'uri': 'file:///src/utils.ts'
+				},
+				'symbol': {
+					'containerKind': '',
+					'containerName': '/src/utils',
+					'kind': 'function',
+					'name': 'dedent'
+				}
+			}
+		]
+	},
+	packages: [
+		{
+			'dependencies': [
+				{
+					'attributes': {
+						'name': 'babel-code-frame',
+						'version': '^6.20.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'colors',
+						'version': '^1.1.2'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'diff',
+						'version': '^3.0.1'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'findup-sync',
+						'version': '~0.3.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'glob',
+						'version': '^7.1.1'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'optimist',
+						'version': '~0.6.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'resolve',
+						'version': '^1.1.7'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'update-notifier',
+						'version': '^1.0.2'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/babel-code-frame',
+						'version': '^6.20.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/chai',
+						'version': '^3.4.34'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/colors',
+						'version': '^0.6.33'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/diff',
+						'version': '0.0.31'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/findup-sync',
+						'version': '^0.3.29'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/glob',
+						'version': '^5.0.30'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/js-yaml',
+						'version': '^3.5.29'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/mocha',
+						'version': '^2.2.35'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/node',
+						'version': '^6.0.56'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/optimist',
+						'version': '0.0.29'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/resolve',
+						'version': '0.0.4'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': '@types/update-notifier',
+						'version': '^1.0.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'chai',
+						'version': '^3.5.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'js-yaml',
+						'version': '^3.7.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'mocha',
+						'version': '^3.2.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'npm-run-all',
+						'version': '^3.1.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'rimraf',
+						'version': '^2.5.4'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'tslint',
+						'version': 'latest'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'tslint-test-config-non-relative',
+						'version': 'file:test/external/tslint-test-config-non-relative'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'typescript',
+						'version': '2.1.4'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'typescript',
+						'version': '>=2.0.0'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint'
+					}
+				}
+			],
+			'package': {
+				'name': 'tslint',
+				'repoURL': 'https://github.com/palantir/tslint.git',
+				'version': '4.3.1'
+			}
+		},
+		{
+			'dependencies': [
+				{
+					'attributes': {
+						'name': 'tslint-test-config',
+						'version': '../external/tslint-test-config'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint-test-configs'
+					}
+				},
+				{
+					'attributes': {
+						'name': 'tslint-test-custom-rules',
+						'version': '../external/tslint-test-custom-rules'
+					},
+					'hints': {
+						'dependeePackageName': 'tslint-test-configs'
+					}
+				}
+			],
+			'package': {
+				'name': 'tslint-test-configs',
+				'version': '0.0.1'
+			}
+		},
+		{
+			'dependencies': [],
+			'package': {
+				'name': 'tslint-test-config',
+				'version': '0.0.1'
+			}
+		},
+		{
+			'dependencies': [],
+			'package': {
+				'name': 'tslint-test-config-non-relative',
+				'version': '0.0.1'
+			}
+		},
+		{
+			'dependencies': [],
+			'package': {
+				'name': 'tslint-test-custom-rules',
+				'version': '0.0.1'
+			}
+		}
+	],
+	completions: {
+		'src/language/languageServiceHost.ts:62:13': [
+			{
+				'detail': '(method) LanguageServiceEditableHost.editFile(fileName: string, newContent: string): void',
+				'documentation': '',
+				'kind': 2,
+				'label': 'editFile',
+				'sortText': '0'
+			}
+		]
+	},
+	dependencies: [
+		{
+			'attributes': {
+				'name': 'babel-code-frame',
+				'version': '^6.20.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'colors',
+				'version': '^1.1.2'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'diff',
+				'version': '^3.0.1'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'findup-sync',
+				'version': '~0.3.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'glob',
+				'version': '^7.1.1'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'optimist',
+				'version': '~0.6.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'resolve',
+				'version': '^1.1.7'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'update-notifier',
+				'version': '^1.0.2'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/babel-code-frame',
+				'version': '^6.20.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/chai',
+				'version': '^3.4.34'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/colors',
+				'version': '^0.6.33'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/diff',
+				'version': '0.0.31'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/findup-sync',
+				'version': '^0.3.29'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/glob',
+				'version': '^5.0.30'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/js-yaml',
+				'version': '^3.5.29'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/mocha',
+				'version': '^2.2.35'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/node',
+				'version': '^6.0.56'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/optimist',
+				'version': '0.0.29'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/resolve',
+				'version': '0.0.4'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': '@types/update-notifier',
+				'version': '^1.0.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'chai',
+				'version': '^3.5.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'js-yaml',
+				'version': '^3.7.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'mocha',
+				'version': '^3.2.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'npm-run-all',
+				'version': '^3.1.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'rimraf',
+				'version': '^2.5.4'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'tslint',
+				'version': 'latest'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'tslint-test-config-non-relative',
+				'version': 'file:test/external/tslint-test-config-non-relative'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'typescript',
+				'version': '2.1.4'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'typescript',
+				'version': '>=2.0.0'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'tslint-test-config',
+				'version': '../external/tslint-test-config'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint-test-configs'
+			}
+		},
+		{
+			'attributes': {
+				'name': 'tslint-test-custom-rules',
+				'version': '../external/tslint-test-custom-rules'
+			},
+			'hints': {
+				'dependeePackageName': 'tslint-test-configs'
+			}
+		}
+	],
+	symbols: null, // TODO
+	workspaceReferences: null, // TODO
+	documentSymbols: {
+		// TODO
+	}
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,20 +3,24 @@
 
 
 "@types/async@^2.0.32":
-  version "2.0.37"
-  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.37.tgz#7bf2ffba03ae965df99f21d4d41be340d6a322ab"
+  version "2.0.38"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.38.tgz#5c369dcb14788da0621daafa8594a053b0edcb21"
 
 "@types/chai@^3.4.34":
   version "3.4.34"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.4.34.tgz#d5335792823bb09cddd5e38c3d211b709183854d"
 
 "@types/mocha@^2.2.32":
-  version "2.2.35"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.35.tgz#dd3150b62a6de73368109308515c3aa86f81f1ec"
+  version "2.2.38"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.38.tgz#8c188f6e34c2e7c3f1d0127d908d5a36e5a60dc9"
 
 "@types/node@^6.0.46":
-  version "6.0.54"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.54.tgz#65859962ba988052cbdd5c48881395acfdd46931"
+  version "6.0.61"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.61.tgz#eea1748ad99decaf319b571017018631974ac6f0"
+
+"@types/tmp@^0.0.32":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.32.tgz#0d3cb31022f8427ea58c008af32b80da126ca4e3"
 
 accepts@~1.3.3:
   version "1.3.3"
@@ -34,8 +38,8 @@ ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
 
 ansi-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.0.0.tgz#c5061b6e0ef8a81775e50f5d66151bf6bf371107"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
 ansi-styles@^1.1.0:
   version "1.1.0"
@@ -170,19 +174,19 @@ bluebird@^3.0.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
 
 body-parser@^1.15.2:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.15.2.tgz#d7578cf4f1d11d5f6ea804cef35dc7a7ff6dae67"
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.16.0.tgz#924a5e472c6229fb9d69b85a20d5f2532dec788b"
   dependencies:
     bytes "2.4.0"
     content-type "~1.0.2"
-    debug "~2.2.0"
+    debug "2.6.0"
     depd "~1.1.0"
-    http-errors "~1.5.0"
-    iconv-lite "0.4.13"
+    http-errors "~1.5.1"
+    iconv-lite "0.4.15"
     on-finished "~2.3.0"
-    qs "6.2.0"
-    raw-body "~2.1.7"
-    type-is "~1.6.13"
+    qs "6.2.1"
+    raw-body "~2.2.0"
+    type-is "~1.6.14"
 
 boom@2.x.x:
   version "2.10.1"
@@ -382,6 +386,12 @@ debug@2.2.0, debug@~2.2.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
+
+debug@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+  dependencies:
+    ms "0.7.2"
 
 decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -1019,7 +1029,7 @@ htmlparser2@^3.9.0:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
-http-errors@~1.5.0:
+http-errors@~1.5.0, http-errors@~1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.5.1.tgz#788c0d2c1de2c81b9e6e8c01843b6b97eb920750"
   dependencies:
@@ -1043,9 +1053,9 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.13:
-  version "0.4.13"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
+iconv-lite@0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -1068,9 +1078,9 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ipaddr.js@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.1.1.tgz#c791d95f52b29c1247d5df80ada39b8a73647230"
+ipaddr.js@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.2.0.tgz#8aba49c9192799585bdd643e0ccb50e8ae777ba4"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -1385,8 +1395,8 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
 lodash.isequal@^4.0.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.4.0.tgz#6295768e98e14dc15ce8d362ef6340db82852031"
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isobject@~2.4.1:
   version "2.4.1"
@@ -1461,8 +1471,8 @@ lodash.values@~2.4.1:
     lodash.keys "~2.4.1"
 
 lodash@^4.14.0:
-  version "4.17.3"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.3.tgz#557ed7d2a9438cac5fd5a43043ca60cb455e01f7"
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 lodash@~4.13.x:
   version "4.13.1"
@@ -1552,15 +1562,15 @@ mime-db@~1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.12.0.tgz#3d0c63180f458eb10d325aaa37d7c58ae312e9d7"
 
-mime-db@~1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
+mime-db@~1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.26.0.tgz#eaffcd0e4fc6935cf8134da246e2e6c35305adff"
 
 mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.7:
-  version "2.1.13"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
+  version "2.1.14"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee"
   dependencies:
-    mime-db "~1.25.0"
+    mime-db "~1.26.0"
 
 mime-types@~2.0.1:
   version "2.0.14"
@@ -1632,6 +1642,10 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
+ms@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
 multimatch@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
@@ -1697,8 +1711,8 @@ object-assign@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
 object-assign@^4.0.0, object-assign@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-keys@~0.4.0:
   version "0.4.0"
@@ -1741,6 +1755,10 @@ os-locale@^1.4.0:
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
     lcid "^1.0.0"
+
+os-tmpdir@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -1820,11 +1838,11 @@ process-nextick-args@~1.0.6:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
 proxy-addr@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.2.tgz#b4cc5f22610d9535824c123aef9d3cf73c40ba37"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.3.tgz#dc97502f5722e888467b3fa2297a7b1ff47df074"
   dependencies:
     forwarded "~0.1.0"
-    ipaddr.js "1.1.1"
+    ipaddr.js "1.2.0"
 
 pseudomap@^1.0.1:
   version "1.0.2"
@@ -1837,6 +1855,10 @@ punycode@^1.4.1:
 qs@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
+
+qs@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.1.tgz#ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
 
 qs@~3.1.0:
   version "3.1.0"
@@ -1863,12 +1885,12 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raw-body@~2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.1.7.tgz#adfeace2e4fb3098058014d08c072dcc59758774"
+raw-body@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"
   dependencies:
     bytes "2.4.0"
-    iconv-lite "0.4.13"
+    iconv-lite "0.4.15"
     unpipe "1.0.0"
 
 read-pkg-up@^1.0.1:
@@ -2008,8 +2030,8 @@ rimraf@2:
     glob "^7.0.5"
 
 sanitize-html@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.13.0.tgz#4ee17cbec516bfe32f2ce6686a569d7e6b4f3631"
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.14.1.tgz#730ffa2249bdf18333effe45b286173c9c5ad0b8"
   dependencies:
     htmlparser2 "^3.9.0"
     regexp-quote "0.0.0"
@@ -2037,14 +2059,32 @@ send@0.14.1:
     range-parser "~1.2.0"
     statuses "~1.3.0"
 
+send@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.14.2.tgz#39b0438b3f510be5dc6f667a11f71689368cdeef"
+  dependencies:
+    debug "~2.2.0"
+    depd "~1.1.0"
+    destroy "~1.0.4"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.7.0"
+    fresh "0.3.0"
+    http-errors "~1.5.1"
+    mime "1.3.4"
+    ms "0.7.2"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.3.1"
+
 serve-static@~1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.11.1.tgz#d6cce7693505f733c759de57befc1af76c0f0805"
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.11.2.tgz#2cf9889bd4435a320cc36895c9aa57bd662e6ac7"
   dependencies:
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     parseurl "~1.3.1"
-    send "0.14.1"
+    send "0.14.2"
 
 setprototypeof@1.0.2:
   version "1.0.2"
@@ -2071,8 +2111,8 @@ source-map-support@^0.3.2:
     source-map "0.1.32"
 
 source-map-support@^0.4.0:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.8.tgz#4871918d8a3af07289182e974e32844327b2e98b"
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.10.tgz#d7b19038040a14c0837a18e630a196453952b378"
   dependencies:
     source-map "^0.5.3"
 
@@ -2117,8 +2157,8 @@ split@0.3:
     through "2"
 
 sshpk@^1.7.0:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.10.1.tgz#30e1a5d329244974a1af61511339d595af6638b0"
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.10.2.tgz#d5a804ce22695515638e798dbe23273de070a5fa"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -2135,7 +2175,7 @@ stat-mode@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502"
 
-"statuses@>= 1.3.1 < 2", statuses@~1.3.0:
+"statuses@>= 1.3.1 < 2", statuses@~1.3.0, statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
@@ -2273,6 +2313,12 @@ time-stamp@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.0.1.tgz#9f4bd23559c9365966f3302dbba2b07c6b99b151"
 
+tmp@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 to-absolute-glob@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz#1cdfa472a9ef50c239ee66999b662ca0eb39937f"
@@ -2335,7 +2381,7 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-type-is@~1.6.13:
+type-is@~1.6.13, type-is@~1.6.14:
   version "1.6.14"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.14.tgz#e219639c17ded1ca0789092dd54a03826b817cb2"
   dependencies:


### PR DESCRIPTION
- adding e2e tests that clone specific repository/revision and then testing LSP protocol using cloned repository as workspace root
- fixed flaky packages test (packages must be sorted)
- added in-memory file system implementation
- added ability to use specific resolver to construct path from components. The reason is that on Windows in VFS mode there may be a request to read content of "/" directory backed by the local filesystem which causes `path.resolve(root, component)` to produce `/` AKA `C:\`
- added possibility to run e2e tests only or exclude them by using npm scripts `test-e2e` and `test-lsp`