### PR TITLE
Hand off requests to child processes by effort

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -34,7 +34,7 @@ export interface TraceOptions {
 	logfile?: string;
 }
 
-export function newConnection(input: any, output: any, trace: TraceOptions): IConnection {
+export function newConnection(input: NodeJS.ReadableStream, output: NodeJS.WritableStream, trace: TraceOptions): IConnection {
 
 	const reader = new StreamMessageReader(input);
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -64,29 +64,12 @@ export function newConnection(input: NodeJS.ReadableStream, output: NodeJS.Writa
 	}
 
 	const connection = createConnection(reader, writer);
+
+	// Remove vscode-languageserver's stream listeners that kill the process if the stream is closed
 	input.removeAllListeners('end');
 	input.removeAllListeners('close');
 	output.removeAllListeners('end');
 	output.removeAllListeners('close');
-
-	let closed = false;
-	function close() {
-		if (!closed) {
-			if ((<fs_.ReadStream>input).close) {
-				(<fs_.ReadStream>input).close();
-			}
-			if ((<fs_.WriteStream>output).close) {
-				(<fs_.WriteStream>output).close();
-			}
-			closed = true;
-		}
-	}
-
-	// We attach one notification handler on `exit` here to handle the
-	// teardown of the connection.  If other handlers want to do
-	// something on connection destruction, they should register a
-	// handler on `shutdown`.
-	connection.onNotification(rt.ExitRequest.type, close);
 
 	return connection;
 }

--- a/src/master-connection.ts
+++ b/src/master-connection.ts
@@ -32,16 +32,34 @@ import * as rt from './request-type';
  * delegate to worker one. On initialize, the master handler forwards
  * the request to both workers, but only returns the response from
  * worker one. All notifications are forwarded to both workers.
+ *
+ * @param master       The connection to register on
+ * @param leigthWeight Connection for short-running requests
+ * @param heavyDuty    Connection for long-running requests
  */
-export function registerMasterHandler(connection: IConnection, one: IConnection, two: IConnection): void {
-	connection.onRequest(rt.InitializeRequest.type, async (params: InitializeParams): Promise<rt.InitializeResult> => {
-		const resultOne = one.sendRequest(rt.InitializeRequest.type, params);
-		two.sendRequest(rt.InitializeRequest.type, params);
+export function registerMasterHandler(master: IConnection, leightWeight: IConnection, heavyDuty: IConnection): void {
+
+	// Proxy calls from the worker to the master
+
+	for (const worker of [leightWeight, heavyDuty]) {
+		worker.onRequest(rt.ReadFileRequest.type, async (params: any): Promise<any> => {
+			return master.sendRequest(rt.ReadFileRequest.type, params);
+		});
+		worker.onRequest(rt.ReadDirRequest.type, async (params: any): Promise<any> => {
+			return master.sendRequest(rt.ReadDirRequest.type, params);
+		});
+	}
+
+	// Notifications (both workers)
+
+	master.onRequest(rt.InitializeRequest.type, async (params: InitializeParams): Promise<rt.InitializeResult> => {
+		const resultOne = leightWeight.sendRequest(rt.InitializeRequest.type, params);
+		heavyDuty.sendRequest(rt.InitializeRequest.type, params);
 		return resultOne;
 	});
 
-	connection.onShutdown(() => {
-		for (const worker of [one, two]) {
+	master.onShutdown(() => {
+		for (const worker of [leightWeight, heavyDuty]) {
 			worker.sendRequest(rt.ShutdownRequest.type);
 
 			// The master's exit notification is not forwarded to the worker, so send it here.
@@ -49,78 +67,73 @@ export function registerMasterHandler(connection: IConnection, one: IConnection,
 		}
 	});
 
-	connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => {
-		for (const worker of [one, two]) {
+	master.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => {
+		for (const worker of [leightWeight, heavyDuty]) {
 			worker.sendNotification(rt.TextDocumentDidOpenNotification.type, params)
 		}
 	});
 
-	connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => {
-		for (const worker of [one, two]) {
+	master.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => {
+		for (const worker of [leightWeight, heavyDuty]) {
 			worker.sendNotification(rt.TextDocumentDidChangeNotification.type, params);
 		}
 	});
 
-	connection.onDidSaveTextDocument((params: DidSaveTextDocumentParams) => {
-		for (const worker of [one, two]) {
+	master.onDidSaveTextDocument((params: DidSaveTextDocumentParams) => {
+		for (const worker of [leightWeight, heavyDuty]) {
 			worker.sendNotification(rt.TextDocumentDidSaveNotification.type, params);
 		}
 	});
 
-	connection.onDidCloseTextDocument((params: DidCloseTextDocumentParams) => {
-		for (const worker of [one, two]) {
+	master.onDidCloseTextDocument((params: DidCloseTextDocumentParams) => {
+		for (const worker of [leightWeight, heavyDuty]) {
 			worker.sendNotification(rt.TextDocumentDidCloseNotification.type, params);
 		}
 	});
 
-	connection.onDefinition(async (params: TextDocumentPositionParams): Promise<Definition> => {
-		const resps = [one, two].map((worker) => {
-			return worker.sendRequest(rt.DefinitionRequest.type, params);
-		});
-		return promiseFirstSuccess(resps);
+	// Short-running requests (worker one)
+	// These are all that can typically only need very specific files to be parsed
+
+	master.onDefinition(async (params: TextDocumentPositionParams): Promise<Definition> => {
+		return leightWeight.sendRequest(rt.DefinitionRequest.type, params);
 	});
 
-	connection.onHover(async (params: TextDocumentPositionParams): Promise<Hover> => {
-		const resps = [one, two].map((worker) => {
-			return worker.sendRequest(rt.HoverRequest.type, params);
-		});
-		return promiseFirstSuccess(resps);
+	master.onHover(async (params: TextDocumentPositionParams): Promise<Hover> => {
+		return leightWeight.sendRequest(rt.HoverRequest.type, params);
 	});
 
-	connection.onRequest(rt.WorkspaceSymbolsRequest.type, async (params: rt.WorkspaceSymbolParams): Promise<SymbolInformation[]> => {
-		return one.sendRequest(rt.WorkspaceSymbolsRequest.type, params);
+	// Long-running requests (worker two)
+	// These are all that require compilation of the full workspace
+
+	master.onRequest(rt.WorkspaceSymbolsRequest.type, async (params: rt.WorkspaceSymbolParams): Promise<SymbolInformation[]> => {
+		return heavyDuty.sendRequest(rt.WorkspaceSymbolsRequest.type, params);
 	});
 
-	connection.onRequest(rt.DocumentSymbolRequest.type, async (params: DocumentSymbolParams): Promise<SymbolInformation[]> => {
-		return one.sendRequest(rt.DocumentSymbolRequest.type, params);
+	master.onRequest(rt.DocumentSymbolRequest.type, async (params: DocumentSymbolParams): Promise<SymbolInformation[]> => {
+		return heavyDuty.sendRequest(rt.DocumentSymbolRequest.type, params);
 	});
 
-	connection.onRequest(rt.WorkspaceReferenceRequest.type, async (params: rt.WorkspaceReferenceParams): Promise<rt.ReferenceInformation[]> => {
-		return one.sendRequest(rt.WorkspaceReferenceRequest.type, params);
+	master.onRequest(rt.WorkspaceReferenceRequest.type, async (params: rt.WorkspaceReferenceParams): Promise<rt.ReferenceInformation[]> => {
+		return heavyDuty.sendRequest(rt.WorkspaceReferenceRequest.type, params);
 	});
 
-	connection.onReferences(async (params: ReferenceParams): Promise<Location[]> => {
-		return one.sendRequest(rt.ReferencesRequest.type, params);
+	master.onRequest(rt.DependenciesRequest.type, async (params: any): Promise<any> => {
+		return heavyDuty.sendRequest(rt.DependenciesRequest.type, params);
 	});
-}
 
-function promiseFirstSuccess<T>(promises: Thenable<T>[]): Promise<T> {
-	return new Promise<T>((resolve, reject) => {
-		let doneCt = 0;
-		for (const p of promises) {
-			p.then((result) => {
-				doneCt++;
-				if (doneCt > 1) {
-					return;
-				}
-				return resolve(result);
-			}, (err) => {
-				doneCt++;
-				if (doneCt === 2) {
-					return reject(err);
-				}
-				return;
-			});
-		}
+	master.onRequest(rt.XdefinitionRequest.type, async (params: any): Promise<any> => {
+		return heavyDuty.sendRequest(rt.XdefinitionRequest.type, params);
+	});
+
+	master.onRequest(rt.GlobalRefsRequest.type, async (params: any): Promise<any> => {
+		return heavyDuty.sendRequest(rt.GlobalRefsRequest.type, params);
+	});
+
+	master.onReferences(async (params: ReferenceParams): Promise<Location[]> => {
+		return heavyDuty.sendRequest(rt.ReferencesRequest.type, params);
+	});
+
+	master.onCompletion(async (params: any) => {
+		return heavyDuty.sendRequest(rt.TextDocumentCompletionRequest.type, params);
 	});
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,9 @@ import * as net from 'net';
 import * as cluster from 'cluster';
 
 import { newConnection, registerLanguageHandler, TraceOptions } from './connection';
+import { registerMasterHandler } from './master-connection';
 import { LanguageHandler } from './lang-handler';
+import { IConnection } from 'vscode-languageserver';
 
 async function rewriteConsole() {
 	const consoleErr = console.error;
@@ -27,8 +29,10 @@ export interface ServeOptions extends TraceOptions {
  * serve starts a singleton language server instance that uses a
  * cluster of worker processes to achieve some semblance of
  * parallelism.
+ *
+ * @param createWorkerConnection Should return a connection to a subworker (for example by spawning a child process)
  */
-export async function serve(options: ServeOptions, newLangHandler: () => LanguageHandler): Promise<void> {
+export async function serve(options: ServeOptions, createLangHandler: () => LanguageHandler, createWorkerConnection?: () => IConnection): Promise<void> {
 	rewriteConsole();
 
 	if (cluster.isMaster) {
@@ -45,10 +49,26 @@ export async function serve(options: ServeOptions, newLangHandler: () => Languag
 		});
 	} else {
 		console.error('Listening for incoming LSP connections on', options.lspPort);
-		var server = net.createServer((socket) => {
-			const connection = newConnection(socket, socket, options);
-			registerLanguageHandler(connection, options.strict, newLangHandler());
-			connection.listen();
+		var server = net.createServer(socket => {
+			// This connection listens on the socket
+			const master = newConnection(socket, socket, options);
+			if (createWorkerConnection) {
+				// Spawn two child processes that communicate through STDIN/STDOUT
+				// One gets short-running requests like textDocument/definition,
+				// the other long-running requests like textDocument/references
+				// TODO: Don't spawn new processes on every connection, keep them warm
+				//       Need to make sure exit notifications don't come through and LS supports re-initialization
+				const leightWeightWorker = createWorkerConnection();
+				const heavyDutyWorker = createWorkerConnection();
+
+				registerMasterHandler(master, leightWeightWorker, heavyDutyWorker);
+
+				leightWeightWorker.listen();
+				heavyDutyWorker.listen();
+				master.listen();
+			} else {
+				registerLanguageHandler(master, options.strict, createLangHandler());
+			}
 		});
 
 		server.listen(options.lspPort);


### PR DESCRIPTION
For every TCP worker (provided by node's cluster module) two child processes are spawned, one for long-running requests like references, the other for short-running requests like definition. The spawning is provided by a passed function so the build server can spawn a build server instead (in the future I would like to refactor this a lot to be more object-oriented).

The child processes talk LSP over STDIO, the TCP worker handles proxying messages to/from the socket.

Currently the processes are spawned on an incoming TCP connection, it would be faster to keep them warm, but I need to drop the exit notifications for this and check if the LS supports re-initialization for this.