### PR TITLE
Move chai to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   "dependencies": {
     "async": "^2.1.5",
     "bluebird": "^3.4.7",
+    "chai": "^3.4.34",
+    "chai-as-promised": "^6.0.0",
     "commander": "^2.9.0",
     "glob": "^7.1.1",
     "lodash": "^4.17.4",
@@ -55,8 +57,6 @@
     "@types/mocha": "2.2.32",
     "@types/mz": "0.0.30",
     "@types/node": "6.0.46",
-    "chai": "^3.4.34",
-    "chai-as-promised": "^6.0.0",
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Allows to use the exported test helpers