### PR TITLE
Make tests take a factory instead of a constructor

### DIFF
--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -3,7 +3,7 @@ import * as ts from 'typescript';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { CompletionItemKind, TextDocumentIdentifier, TextDocumentItem } from 'vscode-languageserver';
 import { TextDocumentContentParams, WorkspaceFilesParams } from '../request-type';
-import { TypeScriptService } from '../typescript-service';
+import { TypeScriptService, TypeScriptServiceFactory } from '../typescript-service';
 import chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const assert = chai.assert;
@@ -23,11 +23,11 @@ export interface TestContext {
 /**
  * Returns a function that initializes the test context with a TypeScriptService instance and initializes it (to be used in `beforeEach`)
  *
- * @param TypeScriptServiceConstructor The TypeScriptService subclass to instantiate
+ * @param createService A factory that creates the TypeScript service. Allows to test subclasses of TypeScriptService
  * @param files A Map from URI to file content of files that should be available in the workspace
  */
-export const initializeTypeScriptService = (TypeScriptServiceConstructor: typeof TypeScriptService, files: Map<string, string>) => async function (this: TestContext): Promise<void> {
-	this.service = new TypeScriptServiceConstructor({
+export const initializeTypeScriptService = (createService: TypeScriptServiceFactory, files: Map<string, string>) => async function (this: TestContext): Promise<void> {
+	this.service = createService({
 		getTextDocumentContent(params: TextDocumentContentParams, token?: CancellationToken): Promise<TextDocumentItem> {
 			return Promise.resolve(<TextDocumentItem> {
 				uri: params.textDocument.uri,
@@ -60,13 +60,13 @@ export function shutdownTypeScriptService(this: TestContext): Promise<void> {
 /**
  * Describe a TypeScriptService class
  *
- * @param TypeScriptServiceConstructor The TypeScriptService subclass to describe
+ * @param createService Factory function to create the TypeScriptService instance to describe
  */
-export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScriptService) {
+export function describeTypeScriptService(createService: TypeScriptServiceFactory, shutdownService = shutdownTypeScriptService) {
 
 	describe('Workspace without project files', <any> function (this: TestContext) {
 
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///a.ts', 'const abc = 1; console.log(abc);'],
 			['file:///foo/b.ts', [
 				'/* This is class Foo */',
@@ -86,7 +86,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 			].join('\n')]
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		describe('getDefinition()', <any> function (this: TestContext) {
 			specify('in same file', <any> async function (this: TestContext) {
@@ -299,7 +299,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 
 	describe('Workspace with typings directory', <any> function (this: TestContext) {
 
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///a.ts', "import * as m from 'dep';"],
 			['file:///typings/dep.d.ts', "declare module 'dep' {}"],
 			['file:///src/tsconfig.json', [
@@ -318,7 +318,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 			['file:///src/dir/index.ts', 'import * as m from "dep";']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		describe('getDefinition()', <any> function (this: TestContext) {
 			specify('with tsd.d.ts', <any> async function (this: TestContext) {
@@ -400,12 +400,12 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 
 	describe('Global module', <any> function (this: TestContext) {
 
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///a.ts', 'const rt: GQL.Rt;'],
 			['file:///interfaces.d.ts', 'declare namespace GQL { interface Rt { } }']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		specify('getDefinition()', <any> async function (this: TestContext) {
 			const result = await this.service.getDefinition({
@@ -434,7 +434,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 	});
 
 	describe('DefinitelyTyped', <any> function (this: TestContext) {
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///package.json', JSON.stringify({
 				private: true,
 				name: 'definitely-typed',
@@ -524,7 +524,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 			].join('\n')]
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		describe('getWorkspaceSymbols()', <any> function (this: TestContext) {
 			specify('resolve, with package', <any> async function (this: TestContext) {
@@ -578,7 +578,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 
 	describe('Workspace with root package.json', <any> function (this: TestContext) {
 
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///a.ts', 'class a { foo() { const i = 1;} }'],
 			['file:///foo/b.ts', 'class b { bar: number; baz(): number { return this.bar;}}; function qux() {}'],
 			['file:///c.ts', 'import { x } from "dep/dep";'],
@@ -586,7 +586,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 			['file:///node_modules/dep/dep.ts', 'export var x = 1;']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		describe('getWorkspaceSymbols()', <any> function (this: TestContext) {
 			describe('symbol query', <any> function (this: TestContext) {
@@ -970,7 +970,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 
 	describe('Dependency detection', <any> function (this: TestContext) {
 
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///package.json', JSON.stringify({
 				name: 'tslint',
 				version: '4.0.2',
@@ -1007,7 +1007,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 			})]
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		describe('getDependencies()', <any> function (this: TestContext) {
 			it('should account for all dependencies', <any> async function (this: TestContext) {
@@ -1061,11 +1061,11 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 	});
 
 	describe('TypeScript library', <any> function (this: TestContext) {
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///a.ts', 'let parameters = [];']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		specify('type of parameters should be any[]', <any> async function (this: TestContext) {
 			const result = await this.service.getHover({
@@ -1098,11 +1098,11 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 
 	describe('Live updates', <any> function (this: TestContext) {
 
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///a.ts', 'let parameters = [];']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		specify('hover updates', <any> async function (this: TestContext) {
 
@@ -1187,7 +1187,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 	});
 
 	describe('References and imports', <any> function (this: TestContext) {
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///a.ts', '/// <reference path="b.ts"/>\nnamespace qux {let f : foo;}'],
 			['file:///b.ts', '/// <reference path="foo/c.ts"/>'],
 			['file:///c.ts', 'import * as d from "./foo/d"\nd.bar()'],
@@ -1202,7 +1202,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 			['file:///missing/b.ts', 'namespace t {\n    export interface Bar {\n        id?: number;\n    }}']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		describe('getDefinition()', <any> function (this: TestContext) {
 			it('should resolve symbol imported with tripe-slash reference', <any> async function (this: TestContext) {
@@ -1316,7 +1316,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 	});
 
 	describe('TypeScript libraries', <any> function (this: TestContext) {
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 				['file:///tsconfig.json', JSON.stringify({
 					compilerOptions: {
 						lib: ['es2016', 'dom']
@@ -1325,7 +1325,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 				['file:///a.ts', 'function foo(n: Node): {console.log(n.parentNode, NaN})}']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		describe('getHover()', <any> function (this: TestContext) {
 			it('should load local library file', <any> async function (this: TestContext) {
@@ -1440,7 +1440,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 	});
 
 	describe('getCompletions()', <any> function (this: TestContext) {
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///a.ts', [
 				'class A {',
 				'	/** foo doc*/',
@@ -1473,7 +1473,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 			['file:///empty.ts', '']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		it('produces completions in the same file', <any> async function (this: TestContext) {
 			const result = await this.service.getCompletions({
@@ -1575,7 +1575,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 
 	describe('Special file names', <any> function (this: TestContext) {
 
-		beforeEach(<any> initializeTypeScriptService(TypeScriptServiceConstructor, new Map([
+		beforeEach(<any> initializeTypeScriptService(createService, new Map([
 			['file:///keywords-in-path/class/constructor/a.ts', 'export function a() {}'],
 			['file:///special-characters-in-path/%40foo/b.ts', 'export function b() {}'],
 			['file:///windows/app/master.ts', '/// <reference path="..\\lib\\master.ts" />\nc();'],
@@ -1583,7 +1583,7 @@ export function describeTypeScriptService(TypeScriptServiceConstructor = TypeScr
 			['file:///windows/lib/slave.ts', 'function c() {}']
 		])));
 
-		afterEach(<any> shutdownTypeScriptService);
+		afterEach(<any> shutdownService);
 
 		it('should accept files with TypeScript keywords in path', <any> async function (this: TestContext) {
 			const result = await this.service.getHover({

--- a/src/test/typescript-service.test.ts
+++ b/src/test/typescript-service.test.ts
@@ -3,5 +3,5 @@ import {TypeScriptService} from '../typescript-service';
 import {describeTypeScriptService} from './typescript-service-helpers';
 
 describe('TypeScriptService', () => {
-	describeTypeScriptService(TypeScriptService);
+	describeTypeScriptService((client, options) => new TypeScriptService(client, options));
 });

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -46,6 +46,8 @@ export interface TypeScriptServiceOptions {
 	strict?: boolean;
 }
 
+export type TypeScriptServiceFactory = (client: LanguageClientHandler, options?: TypeScriptServiceOptions) => TypeScriptService;
+
 /**
  * TypeScriptService handles incoming requests and return
  * responses. There is a one-to-one-to-one correspondence between TCP


### PR DESCRIPTION
Subclasses can have a different constructor signature, a factory allows to still create them without breaking the interface.

Also allows to pass a custom shutdown function.