### PR TITLE
Expose updater

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -52,19 +52,19 @@ export class LSPLogger implements Logger {
 export class StreamLogger {
 	constructor(private outStream: NodeJS.WritableStream, private errStream: NodeJS.WritableStream) {}
 	log(...values: any[]): void {
-		this.outStream.write('LOG  ' + format(values) + '\n');
+		this.outStream.write(chalk.grey('DEBUG ' + format(values) + '\n'));
 	}
 
 	info(...values: any[]): void {
-		this.outStream.write(chalk.bgCyan('INFO') + ' ' + format(values) + '\n');
+		this.outStream.write(chalk.bgCyan('INFO') + '  ' + format(values) + '\n');
 	}
 
 	warn(...values: any[]): void {
-		this.errStream.write(chalk.bgYellow('WARN') + ' ' + format(values) + '\n');
+		this.errStream.write(chalk.bgYellow('WARN') + '  ' + format(values) + '\n');
 	}
 
 	error(...values: any[]): void {
-		this.errStream.write(chalk.bgRed('ERR') + '  ' + format(values) + '\n');
+		this.errStream.write(chalk.bgRed('ERROR') + ' ' + format(values) + '\n');
 	}
 }
 

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -724,7 +724,7 @@ export class InMemoryFileSystem implements ts.ParseConfigHost, ts.ModuleResoluti
 	 */
 	add(uri: string, content?: string): void {
 		// Make sure not to override existing content with undefined
-		if (this.files.get(uri) === undefined) {
+		if (content !== undefined || !this.files.has(uri)) {
 			this.files.set(uri, content);
 		}
 		// Add to directory tree

--- a/src/request-type.ts
+++ b/src/request-type.ts
@@ -32,14 +32,6 @@ export interface SymbolDescriptor {
 	package?: PackageDescriptor;
 }
 
-export interface PartialSymbolDescriptor {
-	kind?: string;
-	name?: string;
-	containerKind?: string;
-	containerName?: string;
-	package?: PackageDescriptor;
-}
-
 export namespace SymbolDescriptor {
 	export function create(kind: string, name: string, containerKind: string, containerName: string, pkg?: PackageDescriptor): SymbolDescriptor {
 		return { kind, name, containerKind, containerName, package: pkg };
@@ -60,7 +52,7 @@ export interface WorkspaceSymbolParams {
 	/**
 	 * A set of properties that describe the symbol to look up.
 	 */
-	symbol?: PartialSymbolDescriptor;
+	symbol?: Partial<SymbolDescriptor>;
 
 	/**
 	 * The number of items to which to restrict the results set size.
@@ -74,7 +66,7 @@ export interface WorkspaceSymbolParams {
  * spec).
  */
 export interface WorkspaceReferenceParams {
-	query: PartialSymbolDescriptor;
+	query: Partial<SymbolDescriptor>;
 	hints?: DependencyHints;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,12 +11,23 @@ export interface ServeOptions extends TraceOptions {
 }
 
 /**
- * serve starts a singleton language server instance that uses a
- * cluster of worker processes to achieve some semblance of
- * parallelism.
+ * Creates a Logger prefixed with master or worker ID
+ *
+ * @param logger An optional logger to wrap, e.g. to write to a logfile. Defaults to STDIO
  */
-export async function serve(options: ServeOptions, createLangHandler: (connection: IConnection, logger: Logger) => LanguageHandler): Promise<void> {
-	const logger = new PrefixedLogger(options.logger || new StdioLogger(), cluster.isMaster ? 'master' : `wrkr ${cluster.worker.id}`);
+export function createClusterLogger(logger = new StdioLogger()): Logger {
+	return new PrefixedLogger(logger, cluster.isMaster ? 'master' : `wrkr ${cluster.worker.id}`);
+}
+
+/**
+ * Starts up a cluster of worker processes that listen on the same TCP socket.
+ * Crashing workers are restarted automatically.
+ *
+ * @param options
+ * @param createLangHandler Factory function that is called for each new connection
+ */
+export async function serve(options: ServeOptions, createLangHandler: (connection: IConnection) => LanguageHandler): Promise<void> {
+	const logger = options.logger || createClusterLogger();
 	if (options.clusterSize > 1 && cluster.isMaster) {
 		logger.log(`Spawning ${options.clusterSize} workers`);
 		cluster.on('online', worker => {
@@ -45,7 +56,7 @@ export async function serve(options: ServeOptions, createLangHandler: (connectio
 				logger.log(`Connection ${id} closed (exit notification)`);
 			});
 
-			registerLanguageHandler(connection, createLangHandler(connection, logger));
+			registerLanguageHandler(connection, createLangHandler(connection));
 
 			connection.listen();
 		});

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -29,6 +29,9 @@ export interface TestContext {
 export const initializeTypeScriptService = (createService: TypeScriptServiceFactory, files: Map<string, string>) => async function (this: TestContext): Promise<void> {
 	this.service = createService({
 		getTextDocumentContent(params: TextDocumentContentParams, token?: CancellationToken): Promise<TextDocumentItem> {
+			if (!files.has(params.textDocument.uri)) {
+				return Promise.reject(new Error(`Text document ${params.textDocument.uri} does not exist`));
+			}
 			return Promise.resolve(<TextDocumentItem> {
 				uri: params.textDocument.uri,
 				text: files.get(params.textDocument.uri),

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -30,7 +30,6 @@ import {
 	DependencyReference,
 	InitializeParams,
 	PackageInformation,
-	PartialSymbolDescriptor,
 	ReferenceInformation,
 	SymbolDescriptor,
 	SymbolLocationInformation,
@@ -58,7 +57,16 @@ export type TypeScriptServiceFactory = (client: LanguageClientHandler, options?:
 export class TypeScriptService implements LanguageHandler {
 
 	projectManager: pm.ProjectManager;
+
+	/**
+	 * The rootPath as passed to `initialize` or converted from `rootUri`
+	 */
 	root: string;
+
+	/**
+	 * The root URI as passed to `initialize` or converted from `rootPath`
+	 */
+	protected rootUri: string;
 
 	private emptyQueryWorkspaceSymbols: Promise<SymbolInformation[]>; // cached response for empty workspace/symbol query
 	private traceModuleResolution: boolean;
@@ -87,9 +95,10 @@ export class TypeScriptService implements LanguageHandler {
 	async initialize(params: InitializeParams, token = CancellationToken.None): Promise<InitializeResult> {
 		if (params.rootUri || params.rootPath) {
 			this.root = params.rootPath || util.uri2path(params.rootUri!);
+			this.rootUri = params.rootUri || util.path2uri('', params.rootPath!);
 			this.initializeFileSystems(!this.options.strict && !(params.capabilities.xcontentProvider && params.capabilities.xfilesProvider));
 			this.updater = new FileSystemUpdater(this.fileSystem, this.inMemoryFileSystem);
-			this.projectManager = new pm.ProjectManager(this.root, this.inMemoryFileSystem, this.updater, !!this.options.strict, this.traceModuleResolution);
+			this.projectManager = new pm.ProjectManager(this.root, this.inMemoryFileSystem, this.updater, !!this.options.strict, this.traceModuleResolution, this.logger);
 			// Pre-fetch files in the background
 			// TODO why does ensureAllFiles() fetch less files than ensureFilesForWorkspaceSymbol()?
 			//      (package.json is not fetched)
@@ -1442,7 +1451,7 @@ export class TypeScriptService implements LanguageHandler {
 			this.defUri(item.fileName), item.containerName);
 	}
 
-	private async collectWorkspaceSymbols(configs: pm.ProjectConfiguration[], query?: string, symQuery?: PartialSymbolDescriptor): Promise<SymbolInformation[]> {
+	private async collectWorkspaceSymbols(configs: pm.ProjectConfiguration[], query?: string, symQuery?: Partial<SymbolDescriptor>): Promise<SymbolInformation[]> {
 		const configSymbols: SymbolInformation[][] = await Promise.all(configs.map(async config => {
 			const symbols: SymbolInformation[] = [];
 			await config.ensureAllFiles();

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -22,7 +22,7 @@ import {
 	TextDocumentSyncKind
 } from 'vscode-languageserver';
 import { isCancelledError } from './cancellation';
-import { FileSystem, LocalFileSystem, RemoteFileSystem } from './fs';
+import { FileSystem, FileSystemUpdater, LocalFileSystem, RemoteFileSystem } from './fs';
 import { LanguageClientHandler, LanguageHandler } from './lang-handler';
 import { Logger, LSPLogger } from './logging';
 import * as pm from './project-manager';
@@ -63,9 +63,22 @@ export class TypeScriptService implements LanguageHandler {
 	private emptyQueryWorkspaceSymbols: Promise<SymbolInformation[]>; // cached response for empty workspace/symbol query
 	private traceModuleResolution: boolean;
 
+	/**
+	 * The remote (or local), asynchronous, file system to fetch files from
+	 */
 	protected fileSystem: FileSystem;
 
 	protected logger: Logger;
+
+	/**
+	 * Holds file contents and workspace structure in memory
+	 */
+	protected inMemoryFileSystem: pm.InMemoryFileSystem;
+
+	/**
+	 * Syncs the remote file system with the in-memory file system
+	 */
+	protected updater: FileSystemUpdater;
 
 	constructor(protected client: LanguageClientHandler, protected options: TypeScriptServiceOptions = {}) {
 		this.logger = new LSPLogger(client);
@@ -74,13 +87,9 @@ export class TypeScriptService implements LanguageHandler {
 	async initialize(params: InitializeParams, token = CancellationToken.None): Promise<InitializeResult> {
 		if (params.rootUri || params.rootPath) {
 			this.root = params.rootPath || util.uri2path(params.rootUri!);
-			if (params.capabilities.xcontentProvider && params.capabilities.xfilesProvider) {
-				this.fileSystem = new RemoteFileSystem(this.client);
-			} else {
-				this.fileSystem = new LocalFileSystem(util.uri2path(this.root));
-			}
-			await this.beforeProjectInit();
-			this.projectManager = new pm.ProjectManager(this.root, this.fileSystem, this.options.strict || false, this.traceModuleResolution, this.logger);
+			this.initializeFileSystems(!this.options.strict && !(params.capabilities.xcontentProvider && params.capabilities.xfilesProvider));
+			this.updater = new FileSystemUpdater(this.fileSystem, this.inMemoryFileSystem);
+			this.projectManager = new pm.ProjectManager(this.root, this.inMemoryFileSystem, this.updater, !!this.options.strict, this.traceModuleResolution);
 			// Pre-fetch files in the background
 			// TODO why does ensureAllFiles() fetch less files than ensureFilesForWorkspaceSymbol()?
 			//      (package.json is not fetched)
@@ -112,10 +121,14 @@ export class TypeScriptService implements LanguageHandler {
 	}
 
 	/**
-	 * Called before the ProjectManager is initialized, after the FileSystem was initialized
+	 * Initializes the remote file system and in-memory file system.
+	 * Can be overridden
+	 *
+	 * @param accessDisk Whether the language server is allowed to access the local file system
 	 */
-	protected async beforeProjectInit(): Promise<void> {
-		// To be overridden
+	protected initializeFileSystems(accessDisk: boolean): void {
+		this.fileSystem = accessDisk ? new LocalFileSystem(util.uri2path(this.root)) : new RemoteFileSystem(this.client);
+		this.inMemoryFileSystem = new pm.InMemoryFileSystem(this.root);
 	}
 
 	async shutdown(): Promise<void> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -208,7 +208,7 @@ export function defInfoToSymbolDescriptor(d: ts.DefinitionInfo): rt.SymbolDescri
 	};
 }
 
-export function symbolDescriptorMatch(query: rt.PartialSymbolDescriptor, sym: rt.SymbolDescriptor): boolean {
+export function symbolDescriptorMatch(query: Partial<rt.SymbolDescriptor>, sym: rt.SymbolDescriptor): boolean {
 	for (const key of Object.keys(query)) {
 		if ((<any> query)[key] === undefined) {
 			continue;


### PR DESCRIPTION
A couple of changes:
- Optimize some iterations by using Iterators
- Remove cancellation from file fetching for now. It is too complex to get right with regard to memoization with little benefit and would complicate #115 
- Expose the `FileSystemUpdater` as a protected property of the `TypeScriptService` and remove `beforeProjectInit` hook in favor of `initializeFileSystems`
- Expose some memoization caches so they can be cleared
- Correct logging
- Save all file contents in the `files` URI -> content map. All places where the paths are used were adapted under the assumption that paths and URIs can be converted back and forth to `file://` URLs. This is a step towards #106 