### PR TITLE
Yet another step to cross-repo j2d

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -1015,11 +1015,19 @@ export class ProjectConfiguration {
 	 * @return package name (project name) of a given project
 	 */
 	getPackageName(): string | null {
-		const pkgJsonFile = path_.posix.join(this.rootFilePath, 'package.json');
-		if (this.fs.fileExists(pkgJsonFile)) {
-			return JSON.parse(this.fs.readFile(pkgJsonFile)).name;
+		// package.json may be located at the upper level as well
+		let currentDir = this.rootFilePath;
+		while (true) {
+			const pkgJsonFile = path_.posix.join(currentDir, 'package.json');
+			if (this.fs.fileExists(pkgJsonFile)) {
+				return JSON.parse(this.fs.readFile(pkgJsonFile)).name;
+			}
+			const parentDir = path_.dirname(currentDir);
+			if (parentDir === '.' || parentDir === '/' || parentDir === currentDir) {
+				return null;
+			}
+			currentDir = parentDir;
 		}
-		return null;
 	}
 
 	/**

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -751,7 +751,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				assert.deepEqual(result, []);
 			});
 			specify('dependency reference', <any> async function (this: TestContext) {
-				const result = await this.service.getWorkspaceReference({ query: { name: 'x', containerName: '/node_modules/dep/dep' } });
+				const result = await this.service.getWorkspaceReference({ query: { name: 'x', containerName: '' } });
 				assert.deepEqual(result, [{
 					reference: {
 						range: {
@@ -768,7 +768,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					symbol: {
 						containerKind: '',
-						containerName: '/node_modules/dep/dep',
+						containerName: '',
 						kind: 'var',
 						name: 'x'
 					}
@@ -856,7 +856,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						},
 						symbol: {
 							containerKind: '',
-							containerName: '/node_modules/dep/dep',
+							containerName: '',
 							kind: 'var',
 							name: 'x'
 						}

--- a/src/util.ts
+++ b/src/util.ts
@@ -204,7 +204,7 @@ export function defInfoToSymbolDescriptor(d: ts.DefinitionInfo): rt.SymbolDescri
 		kind: d.kind || '',
 		name: stripQuotes(d.name) || '',
 		containerKind: d.containerKind || '',
-		containerName: (d.containerName ? lastDotCmp(stripQuotes(d.containerName)) : '')
+		containerName: (d.containerName ? stripFileInfo(lastDotCmp(stripQuotes(d.containerName))) : '')
 	};
 }
 
@@ -248,4 +248,14 @@ function stripQuotes(s: string): string {
 function lastDotCmp(s: string): string {
 	const cmps = s.split('.');
 	return cmps[cmps.length - 1];
+}
+
+/**
+ * Strips file part (if any) from container name (last component of container path)
+ * For example TS may return the following name: /node_modules/vscode-jsonrpc/lib/cancellation.
+ * We consider that if name contains path separtor then container name is empty
+ * @param containerName
+ */
+function stripFileInfo(containerName: string): string {
+	return toUnixPath(containerName).indexOf('/') < 0 ? containerName : '';
 }


### PR DESCRIPTION
- fixed package extraction: package.json may be located at the upper level of tsconfig.json
- corrected container name extraction: we should skip name component (if any), so we are taking last part after dot and if it contains path separators then we consider that container name is empty