### PR TITLE
using vscode-uri to transform URI to path and in back

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "vscode-jsonrpc": "^3.1.0",
     "vscode-languageserver": "^3.1.0",
     "vscode-languageserver-types": "^3.0.3",
+    "vscode-uri": "^1.0.0",
     "yarn": "^0.21.3"
   },
   "devDependencies": {

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1362,7 +1362,7 @@ export class TypeScriptService implements LanguageHandler {
 	didOpen(params: DidOpenTextDocumentParams): Promise<void> {
 		const uri = util.uri2reluri(params.textDocument.uri, this.root);
 		return this.projectManager.ensureFilesForHoverAndDefinition(uri).then(() => {
-			this.projectManager.didOpen(util.uri2path(uri), params.textDocument.text);
+			this.projectManager.didOpen(util.uri2relpath(uri, this.root), params.textDocument.text);
 		});
 	}
 
@@ -1378,20 +1378,20 @@ export class TypeScriptService implements LanguageHandler {
 		if (!text) {
 			return;
 		}
-		this.projectManager.didChange(util.uri2path(uri), text);
+		this.projectManager.didChange(util.uri2relpath(uri, this.root), text);
 	}
 
 	didSave(params: DidSaveTextDocumentParams): Promise<void> {
 		const uri = util.uri2reluri(params.textDocument.uri, this.root);
 		return this.projectManager.ensureFilesForHoverAndDefinition(uri).then(() => {
-			this.projectManager.didSave(util.uri2path(uri));
+			this.projectManager.didSave(util.uri2relpath(uri, this.root));
 		});
 	}
 
 	didClose(params: DidCloseTextDocumentParams): Promise<void> {
 		const uri = util.uri2reluri(params.textDocument.uri, this.root);
 		return this.projectManager.ensureFilesForHoverAndDefinition(uri).then(() => {
-			this.projectManager.didClose(util.uri2path(uri));
+			this.projectManager.didClose(util.uri2relpath(uri, this.root));
 		});
 	}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 
 import * as ts from 'typescript';
 import { Position, Range, SymbolKind } from 'vscode-languageserver';
+import Uri from 'vscode-uri';
+
 import * as rt from './request-type';
 
 let strict = false;
@@ -69,29 +71,21 @@ export function convertStringtoSymbolKind(kind: string): SymbolKind {
 }
 
 export function path2uri(root: string, file: string): string {
-	let ret = 'file://';
-	if (!strict && process.platform === 'win32') {
-		ret += '/';
-	}
 	let p;
 	if (root) {
 		p = resolve(root, file);
 	} else {
 		p = file;
 	}
-	p = toUnixPath(p).split('/').map(encodeURIComponent).join('/');
-	return ret + p;
+	return Uri.file(p).toString();
 }
 
 export function uri2path(uri: string): string {
-	if (uri.startsWith('file://')) {
-		uri = uri.substring('file://'.length);
-		if (process.platform === 'win32') {
-			if (!strict) {
-				uri = uri.substring(1);
-			}
+	if (uri.startsWith('file:')) {
+		uri = toUnixPath(Uri.parse(uri).fsPath);
+		if (!strict && process.platform === 'win32' && uri.charAt(0) === '/') {
+			uri = uri.substring(1);
 		}
-		uri = uri.split('/').map(decodeURIComponent).join('/');
 	}
 	return uri;
 }


### PR DESCRIPTION
- using vscode-uri to transform URI to path and in back
- `textDocument/did...` update content by relative path
- I expect that this PR should deal with #114 and #129 