### PR TITLE
Revert LocalFileSystem breaking change

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -68,7 +68,7 @@ export class LocalFileSystem implements FileSystem {
 		const files = await new Promise<string[]>((resolve, reject) => {
 			glob('*', { cwd: root, nodir: true, matchBase: true }, (err, matches) => err ? reject(err) : resolve(matches));
 		});
-		return iterate(files).map(file => baseUri + file);
+		return iterate(files).map(file => baseUri + file.split('/').map(encodeURIComponent).join('/'));
 	}
 
 	async getTextDocumentContent(uri: string): Promise<string> {

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -63,7 +63,7 @@ export class LocalFileSystem implements FileSystem {
 	}
 
 	async getWorkspaceFiles(base?: string): Promise<Iterable<string>> {
-		const root = base ? this.resolveUriToPath(base) : this.rootPath;
+		const root = this.resolveUriToPath(base || this.rootPath);
 		const baseUri = path2uri('', normalizeDir(root)) + '/';
 		const files = await new Promise<string[]>((resolve, reject) => {
 			glob('*', { cwd: root, nodir: true, matchBase: true }, (err, matches) => err ? reject(err) : resolve(matches));

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -63,7 +63,9 @@ export class LocalFileSystem implements FileSystem {
 	}
 
 	async getWorkspaceFiles(base?: string): Promise<Iterable<string>> {
-		const root = this.resolveUriToPath(base || this.rootPath);
+		// alexsaveliev: even if no base provided, still need to call resolveUriToPath
+		// which may be overloaded
+		const root = this.resolveUriToPath(base || path2uri('', this.rootPath));
 		const baseUri = path2uri('', normalizeDir(root)) + '/';
 		const files = await new Promise<string[]>((resolve, reject) => {
 			glob('*', { cwd: root, nodir: true, matchBase: true }, (err, matches) => err ? reject(err) : resolve(matches));

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -63,8 +63,7 @@ export class LocalFileSystem implements FileSystem {
 	}
 
 	async getWorkspaceFiles(base?: string): Promise<Iterable<string>> {
-		// alexsaveliev: even if no base provided, still need to call resolveUriToPath
-		// which may be overloaded
+		// Even if no base provided, still need to call resolveUriToPath which may be overridden
 		const root = this.resolveUriToPath(base || path2uri('', this.rootPath));
 		const baseUri = path2uri('', normalizeDir(root)) + '/';
 		const files = await new Promise<string[]>((resolve, reject) => {

--- a/src/test/fs.test.ts
+++ b/src/test/fs.test.ts
@@ -22,9 +22,12 @@ describe('fs.ts', () => {
 			});
 			baseUri = path2uri('', temporaryDir) + '/';
 			await fs.mkdir(path.join(temporaryDir, 'foo'));
+			await fs.mkdir(path.join(temporaryDir, '@types'));
+			await fs.mkdir(path.join(temporaryDir, '@types', 'diff'));
 			await fs.writeFile(path.join(temporaryDir, 'tweedledee'), 'hi');
 			await fs.writeFile(path.join(temporaryDir, 'tweedledum'), 'bye');
 			await fs.writeFile(path.join(temporaryDir, 'foo', 'bar.ts'), 'baz');
+			await fs.writeFile(path.join(temporaryDir, '@types', 'diff', 'index.d.ts'), 'baz');
 			fileSystem = new LocalFileSystem(toUnixPath(temporaryDir));
 		});
 		after(async () => {
@@ -38,7 +41,8 @@ describe('fs.ts', () => {
 				assert.sameMembers(iterate(await fileSystem.getWorkspaceFiles()).toArray(), [
 					baseUri + 'tweedledee',
 					baseUri + 'tweedledum',
-					baseUri + 'foo/bar.ts'
+					baseUri + 'foo/bar.ts',
+					baseUri + '%40types/diff/index.d.ts'
 				]);
 			});
 			it('should return all files under specific root', async () => {


### PR DESCRIPTION
after my changes buildserver became broken because overridden `resolveUriToPath` wasn't used anymore