### PR TITLE
workspace/symbol corrections

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -483,13 +483,18 @@ export class ProjectManager implements Disposable {
 		}
 		if (!rootdirs.has('') && !this.configs.has('')) {
 			// collecting all the files in workspace by making fake configuration object
-			this.configs.set('', new ProjectConfiguration(this.localFs, '/', this.versions, '', {
+			const tsConfig: any = {
 				compilerOptions: {
 					module: ts.ModuleKind.CommonJS,
 					allowNonTsExtensions: false,
 					allowJs: true
 				}
-			}, this.traceModuleResolution, this.logger));
+			};
+			// if there is at least one config, giving no files to default one
+			if (this.configs.size > 0) {
+				tsConfig.exclude = ['**/*'];
+			}			
+			this.configs.set('', new ProjectConfiguration(this.localFs, '/', this.versions, '', tsConfig, this.traceModuleResolution, this.logger));
 		}
 	}
 }

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -491,6 +491,7 @@ export class ProjectManager implements Disposable {
 				}
 			};
 			// if there is at least one config, giving no files to default one
+			// TODO: it makes impossible to IntelliSense gulpfile.js if there is a tsconfig.json in subdirectory
 			if (this.configs.size > 0) {
 				tsConfig.exclude = ['**/*'];
 			}

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -493,7 +493,7 @@ export class ProjectManager implements Disposable {
 			// if there is at least one config, giving no files to default one
 			if (this.configs.size > 0) {
 				tsConfig.exclude = ['**/*'];
-			}			
+			}
 			this.configs.set('', new ProjectConfiguration(this.localFs, '/', this.versions, '', tsConfig, this.traceModuleResolution, this.logger));
 		}
 	}

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -702,7 +702,7 @@ export class ProjectConfiguration {
 
 	/**
 	 * @param fs file system to use
-	 * @param rootFilePath root file path, relative to workspace hierarchy root
+	 * @param rootFilePath root file path, absolute
 	 * @param configFilePath configuration file path (relative to workspace root)
 	 * @param configContent optional configuration content to use instead of reading configuration file)
 	 */
@@ -749,8 +749,8 @@ export class ProjectConfiguration {
 			if (this.fs.fileExists(pkgJsonFile)) {
 				return JSON.parse(this.fs.readFile(pkgJsonFile)).name;
 			}
-			const parentDir = path_.dirname(currentDir);
-			if (parentDir === '.' || parentDir === '/' || parentDir === currentDir) {
+			const parentDir = path_.posix.dirname(currentDir);
+			if (parentDir === '.' || parentDir === currentDir || currentDir === this.fs.path) {
 				return undefined;
 			}
 			currentDir = parentDir;

--- a/src/test/fs-helpers.ts
+++ b/src/test/fs-helpers.ts
@@ -1,0 +1,23 @@
+import { iterate } from 'iterare';
+import { FileSystem } from '../fs';
+
+/**
+ * Map-based file system that holds map (URI -> content)
+ */
+export class MapFileSystem implements FileSystem {
+
+	constructor(private files: Map<string, string>) { }
+
+	async getWorkspaceFiles(base?: string): Promise<Iterable<string>> {
+		return iterate(this.files.keys())
+			.filter(path => !base || path.startsWith(base));
+	}
+
+	async getTextDocumentContent(uri: string): Promise<string> {
+		const ret = this.files.get(uri);
+		if (ret === undefined) {
+			throw new Error(`Attempt to read not-existent file ${uri}`);
+		}
+		return ret;
+	}
+}

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -12,7 +12,7 @@ describe('ProjectManager', () => {
 	let projectManager: ProjectManager;
 
 	describe('getPackageName()', () => {
-		before(() => {
+		before(async () => {
 			const memfs = new InMemoryFileSystem('/');
 			const localfs = new MapFileSystem(new Map([
 				['file:///package.json', '{"name": "package-name-1"}'],
@@ -22,7 +22,7 @@ describe('ProjectManager', () => {
 			]));
 			const updater = new FileSystemUpdater(localfs, memfs);
 			projectManager = new ProjectManager('/', memfs, updater, true);
-			projectManager.ensureAllFiles();
+			await projectManager.ensureAllFiles();
 		});
 		it('should resolve package name when package.json is at the same level', () => {
 			assert.equal(projectManager.getConfiguration('').getPackageName(), 'package-name-1');

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -7,26 +7,21 @@ import { InMemoryFileSystem } from '../memfs';
 import { ProjectManager } from '../project-manager';
 import { MapFileSystem } from './fs-helpers';
 
-function initialize(files: Map<string, string>): ProjectManager {
-	const memfs = new InMemoryFileSystem('/');
-	const localfs = new MapFileSystem(files);
-	const updater = new FileSystemUpdater(localfs, memfs);
-	return new ProjectManager('/', memfs, updater, true);
-}
-
 describe('ProjectManager', () => {
 
 	let projectManager: ProjectManager;
 
 	describe('getPackageName()', () => {
 		before(() => {
-			projectManager = initialize(
-				new Map([
-					['file:///package.json', '{"name": "package-name-1"}'],
-					['file:///subdirectory-with-tsconfig/package.json', '{"name": "package-name-2"}'],
-					['file:///subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
-					['file:///subdirectory-with-tsconfig/src/dummy.ts', '']
-				]));
+			const memfs = new InMemoryFileSystem('/');
+			const localfs = new MapFileSystem(new Map([
+				['file:///package.json', '{"name": "package-name-1"}'],
+				['file:///subdirectory-with-tsconfig/package.json', '{"name": "package-name-2"}'],
+				['file:///subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
+				['file:///subdirectory-with-tsconfig/src/dummy.ts', '']
+			]));
+			const updater = new FileSystemUpdater(localfs, memfs);
+			projectManager = new ProjectManager('/', memfs, updater, true);
 			projectManager.ensureAllFiles();
 		});
 		it('should resolve package name when package.json is at the same level', () => {

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -1,0 +1,29 @@
+import * as chai from 'chai';
+import chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+import { TypeScriptService } from '../typescript-service';
+import { initializeTypeScriptService, shutdownTypeScriptService, TestContext } from './typescript-service-helpers';
+
+describe('ProjectManager', () => {
+	describe('getPackageName()', function (this: TestContext) {
+		before(async function (this: TestContext) {
+			await initializeTypeScriptService(
+				(client, options) => new TypeScriptService(client, options),
+				new Map([
+					['file:///package.json', '{"name": "package-name-1"}'],
+					['file:///subdirectory-with-tsconfig/package.json', '{"name": "package-name-2"}'],
+					['file:///subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
+					['file:///subdirectory-with-tsconfig/src/dummy.ts', '']
+				])).apply(this);
+			await this.service.projectManager.ensureOwnFiles();
+		} as any);
+		after(shutdownTypeScriptService as any);
+		it('should resolve package name when package.json is at the same level', function (this: TestContext) {
+			assert.equal(this.service.projectManager.getConfiguration('').getPackageName(), 'package-name-1');
+		} as any);
+		it('should resolve package name when package.json is at the upper level', function (this: TestContext) {
+			assert.equal(this.service.projectManager.getConfiguration('subdirectory-with-tsconfig/src/dummy.ts').getPackageName(), 'package-name-2');
+		} as any);
+	} as any);
+});

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -2,28 +2,38 @@ import * as chai from 'chai';
 import chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const assert = chai.assert;
-import { TypeScriptService } from '../typescript-service';
-import { initializeTypeScriptService, shutdownTypeScriptService, TestContext } from './typescript-service-helpers';
+import { FileSystemUpdater } from '../fs';
+import { InMemoryFileSystem } from '../memfs';
+import { ProjectManager } from '../project-manager';
+import { MapFileSystem } from './fs-helpers';
+
+function initialize(files: Map<string, string>): ProjectManager {
+	const memfs = new InMemoryFileSystem('/');
+	const localfs = new MapFileSystem(files);
+	const updater = new FileSystemUpdater(localfs, memfs);
+	return new ProjectManager('/', memfs, updater, true);
+}
 
 describe('ProjectManager', () => {
-	describe('getPackageName()', function (this: TestContext) {
-		before(async function (this: TestContext) {
-			await initializeTypeScriptService(
-				(client, options) => new TypeScriptService(client, options),
+
+	let projectManager: ProjectManager;
+
+	describe('getPackageName()', () => {
+		before(() => {
+			projectManager = initialize(
 				new Map([
 					['file:///package.json', '{"name": "package-name-1"}'],
 					['file:///subdirectory-with-tsconfig/package.json', '{"name": "package-name-2"}'],
 					['file:///subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
 					['file:///subdirectory-with-tsconfig/src/dummy.ts', '']
-				])).apply(this);
-			await this.service.projectManager.ensureOwnFiles();
-		} as any);
-		after(shutdownTypeScriptService as any);
-		it('should resolve package name when package.json is at the same level', function (this: TestContext) {
-			assert.equal(this.service.projectManager.getConfiguration('').getPackageName(), 'package-name-1');
-		} as any);
-		it('should resolve package name when package.json is at the upper level', function (this: TestContext) {
-			assert.equal(this.service.projectManager.getConfiguration('subdirectory-with-tsconfig/src/dummy.ts').getPackageName(), 'package-name-2');
-		} as any);
-	} as any);
+				]));
+			projectManager.ensureAllFiles();
+		});
+		it('should resolve package name when package.json is at the same level', () => {
+			assert.equal(projectManager.getConfiguration('').getPackageName(), 'package-name-1');
+		});
+		it('should resolve package name when package.json is at the upper level', () => {
+			assert.equal(projectManager.getConfiguration('subdirectory-with-tsconfig/src/dummy.ts').getPackageName(), 'package-name-2');
+		});
+	});
 });

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -312,7 +312,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 	describe('Workspace with typings directory', function (this: TestContext) {
 
 		beforeEach(initializeTypeScriptService(createService, new Map([
-			['file:///a.ts', "import * as m from 'dep';"],
+			['file:///src/a.ts', "import * as m from 'dep';"],
 			['file:///typings/dep.d.ts', "declare module 'dep' {}"],
 			['file:///src/tsconfig.json', [
 				'{',
@@ -361,7 +361,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				specify('on import alias', async function (this: TestContext) {
 					const result = await this.service.textDocumentDefinition({
 						textDocument: {
-							uri: 'file:///a.ts'
+							uri: 'file:///src/a.ts'
 						},
 						position: {
 							line: 0,
@@ -385,7 +385,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				specify('on module name', async function (this: TestContext) {
 					const result = await this.service.textDocumentDefinition({
 						textDocument: {
-							uri: 'file:///a.ts'
+							uri: 'file:///src/a.ts'
 						},
 						position: {
 							line: 0,

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -327,7 +327,7 @@ export class TypeScriptService {
 				configuration.ensureAllFiles();
 				const program = configuration.getProgram();
 				if (!program) {
-					return Observable.from([]);
+					return [];
 				}
 				// Get SourceFile object for requested file
 				const sourceFile = this._getSourceFile(configuration, fileName);

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -328,7 +328,7 @@ export class TypeScriptService {
 				const program = configuration.getProgram();
 				if (!program) {
 					return Observable.from([]);
-				}				
+				}
 				// Get SourceFile object for requested file
 				const sourceFile = this._getSourceFile(configuration, fileName);
 				if (!sourceFile) {
@@ -782,23 +782,23 @@ export class TypeScriptService {
 	 * @param configuration project configuration
 	 * @param fileName file name to fetch source file for or create it
 	 */
-	private _getSourceFile(configuration: pm.ProjectConfiguration, fileName: string): ts.SourceFile | null {
+	private _getSourceFile(configuration: pm.ProjectConfiguration, fileName: string): ts.SourceFile | undefined {
 		let program = configuration.getProgram();
 		if (!program) {
-			return null;
+			return undefined;
 		}
 		const sourceFile = program.getSourceFile(fileName);
 		if (sourceFile) {
 			return sourceFile;
 		}
 		if (!this.projectManager.hasFile(fileName)) {
-			return null;
+			return undefined;
 		}
 		configuration.getHost().addFile(fileName);
 		configuration.syncProgram();
 		// update program object
 		program = configuration.getProgram();
-		return program ? program.getSourceFile(fileName) : null;
+		return program && program.getSourceFile(fileName);
 	}
 
 	/**
@@ -833,7 +833,7 @@ export class TypeScriptService {
 		if (!program) {
 			return iterate([]);
 		}
-		
+
 		if (query) {
 			let items: Iterable<ts.NavigateToItem>;
 			if (typeof query === 'string') {


### PR DESCRIPTION
These changes are targeted to resolve missing j2d from sourcegraph/javascript-typescript-langserver to microsoft/TypeScript definition

- corrected package extraction (it wasn't worked properly on local file system), added basic project manager functionality tests (for local and VFS modes) to cover fix with unit tests
- Handling compilation errors and internal TS errors: if there was a compilation error program object cannot be built. We should tolerate this case and provide no data
- **SIGNIFICANT**: Restricting files for default configuration object, giving access to them only if there were no other objects found. Otherwise it may collect files that weren't supposed to be compiled