### PR TITLE
Removed relative path resolution for referenced files

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -346,15 +346,10 @@ export class ProjectManager implements Disposable {
 						// Resolve triple slash references relative to current file
 						// instead of using module resolution host because it behaves
 						// differently in "nodejs" mode
-						.map(referencedFile => util.toUnixPath(
-							path_.relative(
-								this.rootPath,
-								resolver.resolve(
-									this.rootPath,
-									resolver.dirname(filePath),
-									util.toUnixPath(referencedFile.fileName)
-								)
-							)
+						.map(referencedFile => resolver.resolve(
+							this.rootPath,
+							resolver.dirname(filePath),
+							util.toUnixPath(referencedFile.fileName)
 						))
 				);
 			})


### PR DESCRIPTION
- do not resolving referenced files relative to root anymore because they are converted directly into URI w/o additional resolution back to abs path

@tomv564 will appreciate unit test, thanks!