### PR TITLE
Do not add global .d.ts files in node_modules

### DIFF
--- a/src/memfs.ts
+++ b/src/memfs.ts
@@ -236,33 +236,6 @@ export class InMemoryFileSystem implements ts.ParseConfigHost, ts.ModuleResoluti
 }
 
 /**
- * Iterates over in-memory cache calling given function on each node until callback signals abort or all nodes were traversed
- */
-export function walkInMemoryFs(fs: InMemoryFileSystem, rootdir: string, walkfn: (path: string, isdir: boolean) => Error | void): Error | void {
-	const err = walkfn(rootdir, true);
-	if (err) {
-		if (err === skipDir) {
-			return;
-		}
-		return err;
-	}
-	const { files, directories } = fs.getFileSystemEntries(rootdir);
-	for (const file of files) {
-		const err = walkfn(path_.posix.join(rootdir, file), false);
-		if (err) {
-			return err;
-		}
-	}
-	for (const dir of directories) {
-		const err = walkInMemoryFs(fs, path_.posix.join(rootdir, dir), walkfn);
-		if (err) {
-			return err;
-		}
-	}
-	return;
-}
-
-/**
  * TypeScript library files fetched from the local file system (bundled TS)
  */
 export const typeScriptLibraries: Map<string, string> = new Map<string, string>();
@@ -285,11 +258,3 @@ fs_.readdirSync(path).forEach(file => {
 export function isTypeScriptLibrary(path: string): boolean {
 	return typeScriptLibraries.has(util.toUnixPath(path));
 }
-
-/**
- * Indicates that tree traversal function should stop
- */
-export const skipDir: Error = {
-	name: 'WALK_FN_SKIP_DIR',
-	message: ''
-};

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -8,7 +8,7 @@ import * as url from 'url';
 import { Disposable } from 'vscode-languageserver';
 import { FileSystemUpdater } from './fs';
 import { Logger, NoopLogger } from './logging';
-import { InMemoryFileSystem, walkInMemoryFs } from './memfs';
+import { InMemoryFileSystem } from './memfs';
 import * as util from './util';
 
 /**
@@ -831,17 +831,6 @@ export class ProjectConfiguration {
 		const base = dir || this.fs.path;
 		const configParseResult = ts.parseJsonConfigFileContent(configObject, this.fs, base);
 		const expFiles = configParseResult.fileNames;
-
-		// Add globals that might exist in dependencies
-		const nodeModulesDir = path_.posix.join(base, 'node_modules');
-		const err = walkInMemoryFs(this.fs, nodeModulesDir, (path, isdir) => {
-			if (!isdir && util.isGlobalTSFile(path)) {
-				expFiles.push(path);
-			}
-		});
-		if (err) {
-			throw err;
-		}
 
 		const options = configParseResult.options;
 		if (/(^|\/)jsconfig\.json$/.test(this.configFilePath)) {


### PR DESCRIPTION
This caused definitions in node_modules, like `node_modules/@reactivex/rxjs/typings/globals/node/node.d.ts` to be used instead of `node_modules/@types/node/index.d.ts`.
If a global file is supposed to be included, it should be included explicitly through tsconfig.json or a triple slash reference.

Also removes the last usage of `walkInMemoryFs` (we have an iterator API for that now)