### PR TITLE
Correct DefinitelyTyped workspace/symbol handling

### DIFF
--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -535,7 +535,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 		afterEach(shutdownService as any);
 
 		describe('workspaceSymbol()', function (this: TestContext) {
-			it('should find the symbol by SymbolDescriptor query with name and package name', async function (this: TestContext) {
+			it('should find a symbol by SymbolDescriptor query with name and package name', async function (this: TestContext) {
 				const result = await this.service.workspaceSymbol({
 					symbol: { name: 'resolveCallback', package: { name: '@types/resolve' } },
 					limit: 10
@@ -558,7 +558,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					name: 'resolveCallback'
 				}]);
 			} as any);
-			it('should find the symbol by SymbolDescriptor query with name and empty containerKind', async function (this: TestContext) {
+			it('should find a symbol by SymbolDescriptor query with name, package name and empty containerKind', async function (this: TestContext) {
 				const result = await this.service.workspaceSymbol({
 					symbol: { name: 'resolveCallback', containerKind: '', package: { name: '@types/resolve' } },
 					limit: 10

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -481,29 +481,27 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				'declare function resolve(id: string, cb: resolveCallback): void;',
 				''
 			].join('\n')],
-			['file:///types/resolve/tsconfig.json', [
-				'{',
-				'	"compilerOptions": {',
-				'		"module": "commonjs",',
-				'		"lib": [',
-				'			"es6"',
-				'		],',
-				'		"noImplicitAny": true,',
-				'		"noImplicitThis": true,',
-				'		"strictNullChecks": false,',
-				'		"baseUrl": "../",',
-				'		"typeRoots": [',
-				'			"../"',
-				'		],',
-				'		"types": [],',
-				'		"noEmit": true,',
-				'		"forceConsistentCasingInFileNames": true',
-				'	},',
-				'	"files": [',
-				'		"index.d.ts"',
-				'	]',
-				'}'
-			].join('\n')],
+			['file:///types/resolve/tsconfig.json', JSON.stringify({
+				compilerOptions: {
+					module: 'commonjs',
+					lib: [
+						'es6'
+					],
+					noImplicitAny: true,
+					noImplicitThis: true,
+					strictNullChecks: false,
+					baseUrl: '../',
+					typeRoots: [
+						'../'
+					],
+					types: [],
+					noEmit: true,
+					forceConsistentCasingInFileNames: true
+				},
+				files: [
+					'index.d.ts'
+				]
+			})],
 			['file:///types/notResolve/index.d.ts', [
 				'/// <reference types="node" />',
 				'',
@@ -511,29 +509,27 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				'declare function resolve(id: string, cb: resolveCallback): void;',
 				''
 			].join('\n')],
-			['file:///types/notResolve/tsconfig.json', [
-				'{',
-				'	"compilerOptions": {',
-				'		"module": "commonjs",',
-				'		"lib": [',
-				'			"es6"',
-				'		],',
-				'		"noImplicitAny": true,',
-				'		"noImplicitThis": true,',
-				'		"strictNullChecks": false,',
-				'		"baseUrl": "../",',
-				'		"typeRoots": [',
-				'			"../"',
-				'		],',
-				'		"types": [],',
-				'		"noEmit": true,',
-				'		"forceConsistentCasingInFileNames": true',
-				'	},',
-				'	"files": [',
-				'		"index.d.ts"',
-				'	]',
-				'}'
-			].join('\n')]
+			['file:///types/notResolve/tsconfig.json', JSON.stringify({
+				compilerOptions: {
+					module: 'commonjs',
+					lib: [
+						'es6'
+					],
+					noImplicitAny: true,
+					noImplicitThis: true,
+					strictNullChecks: false,
+					baseUrl: '../',
+					typeRoots: [
+						'../'
+					],
+					types: [],
+					noEmit: true,
+					forceConsistentCasingInFileNames: true
+				},
+				files: [
+					'index.d.ts'
+				]
+			})]
 		])) as any);
 
 		afterEach(shutdownService as any);

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -474,14 +474,14 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					'types-publisher': 'Microsoft/types-publisher#production'
 				}
 			}, null, 4)],
-			['file:///resolve/index.d.ts', [
+			['file:///types/resolve/index.d.ts', [
 				'/// <reference types="node" />',
 				'',
 				'type resolveCallback = (err: Error, resolved?: string) => void;',
 				'declare function resolve(id: string, cb: resolveCallback): void;',
 				''
 			].join('\n')],
-			['file:///resolve/tsconfig.json', [
+			['file:///types/resolve/tsconfig.json', [
 				'{',
 				'	"compilerOptions": {',
 				'		"module": "commonjs",',
@@ -504,14 +504,14 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				'	]',
 				'}'
 			].join('\n')],
-			['file:///notResolve/index.d.ts', [
+			['file:///types/notResolve/index.d.ts', [
 				'/// <reference types="node" />',
 				'',
 				'type resolveCallback = (err: Error, resolved?: string) => void;',
 				'declare function resolve(id: string, cb: resolveCallback): void;',
 				''
 			].join('\n')],
-			['file:///notResolve/tsconfig.json', [
+			['file:///types/notResolve/tsconfig.json', [
 				'{',
 				'	"compilerOptions": {',
 				'		"module": "commonjs",',
@@ -539,7 +539,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 		afterEach(shutdownService as any);
 
 		describe('workspaceSymbol()', function (this: TestContext) {
-			specify('resolve, with package', async function (this: TestContext) {
+			it('should find the symbol by SymbolDescriptor query with name and package name', async function (this: TestContext) {
 				const result = await this.service.workspaceSymbol({
 					symbol: { name: 'resolveCallback', package: { name: '@types/resolve' } },
 					limit: 10
@@ -557,12 +557,12 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 								line: 2
 							}
 						},
-						uri: 'file:///resolve/index.d.ts'
+						uri: 'file:///types/resolve/index.d.ts'
 					},
 					name: 'resolveCallback'
 				}]);
 			} as any);
-			specify('resolve, with package, empty containerKind', async function (this: TestContext) {
+			it('should find the symbol by SymbolDescriptor query with name and empty containerKind', async function (this: TestContext) {
 				const result = await this.service.workspaceSymbol({
 					symbol: { name: 'resolveCallback', containerKind: '', package: { name: '@types/resolve' } },
 					limit: 10
@@ -580,7 +580,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 								line: 2
 							}
 						},
-						uri: 'file:///resolve/index.d.ts'
+						uri: 'file:///types/resolve/index.d.ts'
 					},
 					name: 'resolveCallback'
 				}]);

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -471,7 +471,8 @@ export class TypeScriptService {
 
 			// Fetch all files in the package subdirectory
 			const rootUriParts = url.parse(this.rootUri);
-			const packageRoot = 'types/' + params.symbol.package.name.slice('@types/'.length);
+			// All packages are in the types/ subdirectory
+			const packageRoot = params.symbol.package.name.substr(1);
 			const packageRootUri = url.format({ ...rootUriParts, pathname: path_.posix.join(rootUriParts.pathname || '', packageRoot) + '/', search: undefined, hash: undefined });
 			await this.updater.ensureStructure(span);
 			await Promise.all(


### PR DESCRIPTION
- DefinitelyTyped changed their structure so that all packages are now in the `types/` subdirectory
- workspace/symbol on DefinitelyTyped was incredibly slow