### PR TITLE
Diagnostics for opened files

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -38,11 +38,11 @@ export class DiagnosticsPublisher implements DiagnosticsHandler {
 		const diagnosticsByFile = this.groupByFile(diagnostics);
 
 		// add empty diagnostics for fixed files, so client marks them as resolved
-		this.problemFiles.forEach(file => {
+		for (const file of this.problemFiles) {
 			if (!diagnosticsByFile.has(file)) {
 				diagnosticsByFile.set(file, []);
 			}
-		});
+		}
 		this.problemFiles.clear();
 
 		// for each file: publish and set as problem file
@@ -101,14 +101,14 @@ export class DiagnosticsPublisher implements DiagnosticsHandler {
 	 */
 	private groupByFile(diagnostics: ts.Diagnostic[]): Map<string, ts.Diagnostic[]> {
 		const diagnosticsByFile: Map<string, ts.Diagnostic[]> = new Map();
-		diagnostics.forEach(d => {
-			const diagnosticsForFile = diagnosticsByFile.get(d.file.fileName);
+		for (const diagnostic of diagnostics) {
+			const diagnosticsForFile = diagnosticsByFile.get(diagnostic.file.fileName);
 			if (!diagnosticsForFile) {
-				diagnosticsByFile.set(d.file.fileName, [d]);
+				diagnosticsByFile.set(diagnostic.file.fileName, [diagnostic]);
 			} else {
-				diagnosticsForFile.push(d);
+				diagnosticsForFile.push(diagnostic);
 			}
-		});
+		}
 		return diagnosticsByFile;
 	}
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -100,7 +100,7 @@ export class DiagnosticsPublisher implements DiagnosticsHandler {
 	 * @param diagnostics All diagnostics received in an update
 	 */
 	private groupByFile(diagnostics: ts.Diagnostic[]): Map<string, ts.Diagnostic[]> {
-		const diagnosticsByFile: Map<string, ts.Diagnostic[]> = new Map();
+		const diagnosticsByFile = new Map<string, ts.Diagnostic[]>();
 		for (const diagnostic of diagnostics) {
 			const diagnosticsForFile = diagnosticsByFile.get(diagnostic.file.fileName);
 			if (!diagnosticsForFile) {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,114 @@
+import * as ts from 'typescript';
+import { DiagnosticSeverity, PublishDiagnosticsParams } from 'vscode-languageserver';
+import { LanguageClient } from './lang-handler';
+import * as util from './util';
+
+/**
+ * Receives file diagnostics (typically implemented to send diagnostics to client)
+ */
+export interface DiagnosticsHandler {
+	updateFileDiagnostics(diagnostics: ts.Diagnostic[]): void;
+}
+
+/**
+ * Forwards diagnostics from typescript calls to LSP diagnostics
+ */
+export class DiagnosticsPublisher implements DiagnosticsHandler {
+	/**
+	 * The files that were last reported to have errors
+	 * If they don't appear in the next update, we must publish empty diagnostics for them.
+	 */
+	private problemFiles: Set<string> = new Set();
+
+	/**
+	 * Requires a connection to the remote client to send diagnostics to
+	 * @param remoteClient
+	 */
+	constructor(private remoteClient: LanguageClient) {}
+
+	/**
+	 * Receives file diagnostics from eg. ts.getPreEmitDiagnostics
+	 * Diagnostics are grouped and published by file, empty diagnostics are sent for files
+	 * not present in subsequent updates.
+	 * @param diagnostics
+	 */
+	updateFileDiagnostics(diagnostics: ts.Diagnostic[]): void {
+
+		// categorize diagnostics by file
+		const diagnosticsByFile = this.groupByFile(diagnostics);
+
+		// add empty diagnostics for fixed files, so client marks them as resolved
+		this.problemFiles.forEach(file => {
+			if (!diagnosticsByFile.has(file)) {
+				diagnosticsByFile.set(file, []);
+			}
+		});
+		this.problemFiles.clear();
+
+		// for each file: publish and set as problem file
+		diagnosticsByFile.forEach((diagnostics, file) => {
+			this.publishFileDiagnostics(file, diagnostics);
+			if (diagnostics.length > 0) {
+				this.problemFiles.add(file);
+			}
+		});
+	}
+
+	/**
+	 * Converts a diagnostic category to an LSP DiagnosticSeverity
+	 * @param category The Typescript DiagnosticCategory
+	 */
+	private parseDiagnosticCategory(category: ts.DiagnosticCategory): DiagnosticSeverity {
+		switch (category) {
+			case ts.DiagnosticCategory.Error:
+				return DiagnosticSeverity.Error;
+			case ts.DiagnosticCategory.Warning:
+				return DiagnosticSeverity.Warning;
+			case ts.DiagnosticCategory.Message:
+				return DiagnosticSeverity.Information;
+				// unmapped: DiagnosticSeverity.Hint
+		}
+	}
+
+	/**
+	 * Sends given diagnostics for a file to the remote client
+	 * @param file Absolute path as specified from the TS API
+	 * @param diagnostics Matching file diagnostics from the TS API, empty to clear errors for file
+	 */
+	private publishFileDiagnostics(file: string, diagnostics: ts.Diagnostic[]): void {
+		const params: PublishDiagnosticsParams = {
+			uri: util.path2uri('', file),
+			diagnostics: diagnostics.map(d => {
+				const text = ts.flattenDiagnosticMessageText(d.messageText, '\n');
+				return {
+					range: {
+						start: d.file.getLineAndCharacterOfPosition(d.start),
+						end: d.file.getLineAndCharacterOfPosition(d.start + d.length)
+					},
+					message: text,
+					severity: this.parseDiagnosticCategory(d.category),
+					code: d.code,
+					source: 'ts'
+				};
+			})
+		};
+		this.remoteClient.textDocumentPublishDiagnostics(params);
+	}
+
+	/**
+	 * Groups all diagnostics per file they were reported on so they can be stored and sent in batches
+	 * @param diagnostics All diagnostics received in an update
+	 */
+	private groupByFile(diagnostics: ts.Diagnostic[]): Map<string, ts.Diagnostic[]> {
+		const diagnosticsByFile: Map<string, ts.Diagnostic[]> = new Map();
+		diagnostics.forEach(d => {
+			const diagnosticsForFile = diagnosticsByFile.get(d.file.fileName);
+			if (!diagnosticsForFile) {
+				diagnosticsByFile.set(d.file.fileName, [d]);
+			} else {
+				diagnosticsForFile.push(d);
+			}
+		});
+		return diagnosticsByFile;
+	}
+}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -102,11 +102,15 @@ export class DiagnosticsPublisher implements DiagnosticsHandler {
 	private groupByFile(diagnostics: ts.Diagnostic[]): Map<string, ts.Diagnostic[]> {
 		const diagnosticsByFile = new Map<string, ts.Diagnostic[]>();
 		for (const diagnostic of diagnostics) {
-			const diagnosticsForFile = diagnosticsByFile.get(diagnostic.file.fileName);
-			if (!diagnosticsForFile) {
-				diagnosticsByFile.set(diagnostic.file.fileName, [diagnostic]);
-			} else {
-				diagnosticsForFile.push(diagnostic);
+			// TODO for some reason non-file diagnostics end up in here (where file is undefined)
+			const fileName = diagnostic.file ? diagnostic.file.fileName : '';
+			if (fileName) {
+				const diagnosticsForFile = diagnosticsByFile.get(fileName);
+				if (!diagnosticsForFile) {
+					diagnosticsByFile.set(fileName, [diagnostic]);
+				} else {
+					diagnosticsForFile.push(diagnostic);
+				}
 			}
 		}
 		return diagnosticsByFile;

--- a/src/lang-handler.ts
+++ b/src/lang-handler.ts
@@ -4,6 +4,7 @@ import { inspect } from 'util';
 import { isReponseMessage, Message, NotificationMessage, RequestMessage, ResponseMessage } from 'vscode-jsonrpc/lib/messages';
 import {
 	LogMessageParams,
+	PublishDiagnosticsParams,
 	TextDocumentIdentifier,
 	TextDocumentItem
 } from 'vscode-languageserver';
@@ -48,6 +49,13 @@ export interface LanguageClient {
 	 * because the server is not supposed to act differently if the cache set failed.
 	 */
 	xcacheSet(params: CacheSetParams): void;
+
+	/**
+	 * Diagnostics are sent from the server to the client to notify the user of errors/warnings
+	 * in a source file
+	 * @param params The diagnostics to send to the client
+	 */
+	textDocumentPublishDiagnostics(params: PublishDiagnosticsParams): void;
 }
 
 /**
@@ -168,5 +176,14 @@ export class RemoteLanguageClient {
 	 */
 	xcacheSet(params: CacheSetParams): void {
 		return this.notify('xcache/set', params);
+	}
+
+	/**
+	 * Diagnostics are sent from the server to the client to notify the user of errors/warnings
+	 * in a source file
+	 * @param params The diagnostics to send to the client
+	 */
+	textDocumentPublishDiagnostics(params: PublishDiagnosticsParams): void {
+		this.notify('textDocument/publishDiagnostics', params);
 	}
 }

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -471,7 +471,7 @@ export class ProjectManager implements Disposable {
 		if (!config) {
 			return;
 		}
-		config.ensureConfigFile();
+		config.ensureConfigFile(span);
 		config.ensureSourceFile(filePath);
 		config.getHost().incProjectVersion();
 		config.syncProgram(span);

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -472,14 +472,9 @@ export class ProjectManager implements Disposable {
 			return;
 		}
 		config.ensureConfigFile();
-
-		// If file was unknown, we add it (which syncs program)
-		// If file was known, we bump the project version and sync
-		const changedToLoadFile = config.ensureSourceFile(filePath);
-		if (!changedToLoadFile) {
-			config.getHost().incProjectVersion();
-			config.syncProgram();
-		}
+		config.ensureSourceFile(filePath);
+		config.getHost().incProjectVersion();
+		config.syncProgram();
 	}
 
 	/**
@@ -974,22 +969,15 @@ export class ProjectConfiguration {
 	 * Ensures a single file is available to the LanguageServiceHost
 	 * @param filePath
 	 */
-	ensureSourceFile(filePath: string): boolean {
+	ensureSourceFile(filePath: string): void {
 		const program = this.getProgram();
 		if (!program) {
-			return false;
+			return;
 		}
-		let changed = false;
 		const sourceFile = program.getSourceFile(filePath);
 		if (!sourceFile) {
 			this.getHost().addFile(filePath);
-			changed = true;
 		}
-		if (changed) {
-			// requery program object to synchonize LanguageService's data
-			this.syncProgram();
-		}
-		return changed;
 	}
 
 	/**

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -474,7 +474,7 @@ export class ProjectManager implements Disposable {
 		config.ensureConfigFile();
 		config.ensureSourceFile(filePath);
 		config.getHost().incProjectVersion();
-		config.syncProgram();
+		config.syncProgram(span);
 	}
 
 	/**

--- a/src/test/diagnostics.test.ts
+++ b/src/test/diagnostics.test.ts
@@ -8,8 +8,9 @@ import { LanguageClient, RemoteLanguageClient } from '../lang-handler';
 
 describe('DiagnosticsPublisher', () => {
 	let langClient: LanguageClient;
-	let diagnosticsManager;
-	const createTSFileDiagnostic = (message: string, file: ts.SourceFile) => {
+	let diagnosticsManager: DiagnosticsPublisher;
+
+	function createTSFileDiagnostic(message: string, file: ts.SourceFile) {
 		return {
 			file,
 			messageText: message,
@@ -18,7 +19,7 @@ describe('DiagnosticsPublisher', () => {
 			category: ts.DiagnosticCategory.Error,
 			code: 33
 		};
-	};
+	}
 	let publishSpy: sinon.SinonSpy;
 	const sourceFile1 = ts.createSourceFile('/file1.ts', '', ts.ScriptTarget.ES2015);
 	const file1FailureA = createTSFileDiagnostic('Failure A', sourceFile1);

--- a/src/test/diagnostics.test.ts
+++ b/src/test/diagnostics.test.ts
@@ -10,7 +10,7 @@ describe('DiagnosticsPublisher', () => {
 	let langClient: LanguageClient & { textDocumentPublishDiagnostics: sinon.SinonSpy };
 	let diagnosticsManager: DiagnosticsPublisher;
 
-	function createTSFileDiagnostic(message: string, file: ts.SourceFile) {
+	function createTSFileDiagnostic(message: string, file: ts.SourceFile): ts.Diagnostic {
 		return {
 			file,
 			messageText: message,

--- a/src/test/diagnostics.test.ts
+++ b/src/test/diagnostics.test.ts
@@ -1,0 +1,219 @@
+import * as chai from 'chai';
+import chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+import { Span } from 'opentracing/lib';
+import * as sinon from 'sinon';
+import * as ts from 'typescript';
+import { LogMessageParams } from 'vscode-languageserver/lib/protocol';
+import { DiagnosticsPublisher } from '../diagnostics';
+import { FileSystemUpdater } from '../fs';
+import { LanguageClient } from '../lang-handler';
+import { InMemoryFileSystem } from '../memfs';
+import { ProjectManager } from '../project-manager';
+import { CacheGetParams, CacheSetParams, TextDocumentContentParams, WorkspaceFilesParams} from '../request-type';
+import { MapFileSystem } from './fs-helpers';
+
+describe('DiagnosticsPublisher', () => {
+	let langClient: LanguageClient;
+	let diagnosticsManager;
+	const createTSFileDiagnostic = (message: string, file: ts.SourceFile) => {
+		return {
+			file,
+			messageText: message,
+			start: 0,
+			length: 4,
+			category: ts.DiagnosticCategory.Error,
+			code: 33
+		};
+	};
+	let publishSpy: sinon.SinonSpy;
+	const sourceFile1 = ts.createSourceFile('/file1.ts', '', ts.ScriptTarget.ES2015);
+	const file1FailureA = createTSFileDiagnostic('Failure A', sourceFile1);
+	const file1FailureB = createTSFileDiagnostic('Failure B', sourceFile1);
+	const failureADiagnostic = {
+		message: 'Failure A',
+		range: { end: { character: 4, line: 0 }, start: { character: 0, line: 0 } },
+		severity: 1,
+		code: 33,
+		source: 'ts'
+	};
+	const failureBDiagnostic = {
+		message: 'Failure B',
+		range: { end: { character: 4, line: 0 }, start: { character: 0, line: 0 } },
+		severity: 1,
+		code: 33,
+		source: 'ts'
+	};
+
+	beforeEach(() => {
+		publishSpy = sinon.spy();
+		langClient = {
+			textDocumentXcontent(params: TextDocumentContentParams, childOf?: Span) {
+				return Promise.reject(new Error('not implemented')); // Promise<TextDocumentItem>;
+			},
+			workspaceXfiles(params: WorkspaceFilesParams, childOf?: Span) {
+				return Promise.reject(new Error('not implemented')); // Promise<TextDocumentIdentifier[]>
+			},
+			windowLogMessage(params: LogMessageParams) {
+				// nop
+			},
+			xcacheGet(params: CacheGetParams, childOf?: Span) {
+				return Promise.reject(new Error('not implemented')); // nop
+			},
+			xcacheSet(params: CacheSetParams) {
+				// nop
+			},
+			textDocumentPublishDiagnostics : publishSpy
+		};
+
+	});
+
+	it('should not update if there are no changes', () => {
+		diagnosticsManager = new DiagnosticsPublisher(langClient);
+		diagnosticsManager.updateFileDiagnostics([]);
+		sinon.assert.notCalled(publishSpy);
+	});
+
+	it('should translate a diagnostic correctly', () => {
+		diagnosticsManager = new DiagnosticsPublisher(langClient);
+		diagnosticsManager.updateFileDiagnostics([file1FailureA]);
+		sinon.assert.calledWithExactly(publishSpy, {
+			diagnostics: [failureADiagnostic],
+			uri: 'file:///file1.ts'
+		});
+	});
+
+	it('should group diagnostics by file', () => {
+		diagnosticsManager = new DiagnosticsPublisher(langClient);
+		diagnosticsManager.updateFileDiagnostics([file1FailureA, file1FailureB]);
+		sinon.assert.calledWithExactly(publishSpy, {
+			diagnostics: [failureADiagnostic, failureBDiagnostic],
+			uri: 'file:///file1.ts'
+		});
+	});
+
+	it('should publish empty diagnostics when file is fixed', () => {
+		diagnosticsManager = new DiagnosticsPublisher(langClient);
+		diagnosticsManager.updateFileDiagnostics([file1FailureA]);
+		sinon.assert.calledWithExactly(publishSpy, {
+			diagnostics: [failureADiagnostic],
+			uri: 'file:///file1.ts'
+		});
+		diagnosticsManager.updateFileDiagnostics([]);
+		sinon.assert.calledWithExactly(publishSpy, {
+			diagnostics: [],
+			uri: 'file:///file1.ts'
+		});
+	});
+});
+
+// Integration tests that include TS compilation.
+describe('Diagnostics', () => {
+	let projectManager: ProjectManager;
+	let langClient: LanguageClient;
+	let diagnosticsPublisher: DiagnosticsPublisher;
+	const errorDiagnostic = {
+		diagnostics: [{
+			message: "Type '33' is not assignable to type 'string'.",
+			range: { end: { character: 10, line: 0 }, start: { character: 6, line: 0 } },
+			severity: 1,
+			source: 'ts',
+			code: 2322
+		}],
+		uri: 'file:///src/dummy.ts'
+	};
+	const subdirectoryErrorDiagnostic = {
+		diagnostics: errorDiagnostic.diagnostics,
+		uri: 'file:///subdirectory-with-tsconfig/src/dummy.ts'
+	};
+	const emptyDiagnostic = {
+		diagnostics: [],
+		uri: 'file:///src/dummy.ts'
+	};
+	const exportContent = 'export function getNumber(): number { return 0; }';
+	const importContent = 'import {getNumber} from "./export"; getNumber();';
+
+	const emptyImportDiagnostic = {
+		diagnostics: [],
+		uri: 'file:///src/import.ts'
+	};
+	const importDiagnostic = {
+		diagnostics: [{
+			message: "Module '\"/src/export\"' has no exported member 'getNumber'.",
+			range: { end: { character: 17, line: 0 }, start: { character: 8, line: 0 } },
+			severity: 1,
+			source: 'ts',
+			code: 2305
+		}],
+		uri: 'file:///src/import.ts'
+	};
+
+	beforeEach(async () => {
+		const memfs = new InMemoryFileSystem('/');
+		const localfs = new MapFileSystem(new Map([
+			['file:///package.json', '{"name": "package-name-1"}'],
+			['file:///tsconfig.json', '{"include": ["src/*.ts"]}'],
+			['file:///src/export.ts', exportContent],
+			['file:///src/import.ts', importContent],
+			['file:///src/dummy.ts', ['const text: string = 33;'].join('\n')],
+			['file:///subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
+			['file:///subdirectory-with-tsconfig/src/dummy.ts', '']
+		]));
+		const updater = new FileSystemUpdater(localfs, memfs);
+		langClient = {
+			textDocumentXcontent(params: TextDocumentContentParams, childOf?: Span) {
+				return Promise.reject(new Error('not implemented')); // Promise<TextDocumentItem>;
+			},
+			workspaceXfiles(params: WorkspaceFilesParams, childOf?: Span) {
+				return Promise.reject(new Error('not implemented')); // Promise<TextDocumentIdentifier[]>
+			},
+			windowLogMessage(params: LogMessageParams) {
+				// nop
+			},
+			xcacheGet(params: CacheGetParams, childOf?: Span) {
+				return Promise.reject(new Error('not implemented')); // nop
+			},
+			xcacheSet(params: CacheSetParams) {
+				// nop
+			},
+			textDocumentPublishDiagnostics : sinon.spy()
+		};
+		diagnosticsPublisher = new DiagnosticsPublisher(langClient);
+		projectManager = new ProjectManager('/', memfs, updater, diagnosticsPublisher, true);
+		await projectManager.ensureAllFiles();
+	});
+
+	it('should update diagnostics when opening a file', () => {
+		projectManager.didOpen('file:///src/dummy.ts', 'const text: string = 33;');
+		sinon.assert.calledOnce(langClient.textDocumentPublishDiagnostics as sinon.SinonSpy);
+		sinon.assert.calledWithExactly(langClient.textDocumentPublishDiagnostics as sinon.SinonSpy, errorDiagnostic);
+	});
+
+	it('should update diagnostics when error is fixed', () => {
+		const publishSpy = langClient.textDocumentPublishDiagnostics as sinon.SinonSpy;
+		projectManager.didOpen('file:///src/dummy.ts', 'const text: string = 33;');
+		sinon.assert.calledWith(publishSpy, errorDiagnostic);
+		// TODO: there are many calls to publish diagnostics here, investigate if some can be avoided.
+		projectManager.didChange('file:///src/dummy.ts', 'const text: string = "33";');
+		publishSpy.lastCall.calledWith(emptyDiagnostic);
+	});
+
+	it('should publish when a dependent file breaks an import', () => {
+		const publishSpy = langClient.textDocumentPublishDiagnostics as sinon.SinonSpy;
+		projectManager.didOpen('file:///src/import.ts', importContent);
+		projectManager.didOpen('file:///src/export.ts', exportContent);
+		sinon.assert.notCalled(publishSpy);
+
+		projectManager.didChange('file:///src/export.ts', exportContent.replace('getNumber', 'getNumb'));
+		sinon.assert.calledWith(publishSpy, importDiagnostic);
+
+		projectManager.didChange('file:///src/export.ts', exportContent);
+		publishSpy.lastCall.calledWith(emptyImportDiagnostic);
+	});
+
+	it('should report correct url when publishing diagnostics for child configurations', () => {
+		projectManager.didOpen('file:///subdirectory-with-tsconfig/src/dummy.ts', 'const text: string = 33;');
+		sinon.assert.calledOnce(langClient.textDocumentPublishDiagnostics as sinon.SinonSpy);
+		sinon.assert.calledWithExactly(langClient.textDocumentPublishDiagnostics as sinon.SinonSpy, subdirectoryErrorDiagnostic);
+	});
+});

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -90,8 +90,9 @@ describe('ProjectManager', () => {
 		});
 		it('should compile opened file and return diagnostics', async () => {
 			projectManager.didOpen('file:///src/dummy.ts', 'const num: number = "banana";');
-			const lastArgs = diagnosticsSpy.lastCall.args[0];
-			assert.equal(lastArgs.length, 1);
+			sinon.assert.called(diagnosticsSpy);
+			const lastDiagnostics = diagnosticsSpy.lastCall.args[0];
+			assert.equal(lastDiagnostics.length, 1);
 		});
 	});
 	describe('didChange()', () => {
@@ -109,11 +110,11 @@ describe('ProjectManager', () => {
 		});
 		it('should update program and get updated diagnostics', async () => {
 			projectManager.didOpen('file:///src/dummy.ts', 'const num: number = "banana";');
-			let lastArgs = diagnosticsSpy.lastCall.args[0];
-			assert.equal(lastArgs.length, 1);
+			sinon.assert.calledWith(diagnosticsSpy, []);
+
 			projectManager.didChange('file:///src/dummy.ts', 'const num: number = 55;');
-			lastArgs = diagnosticsSpy.lastCall.args[0];
-			assert.equal(lastArgs.length, 0);
+			const lastDiagnostics = diagnosticsSpy.lastCall.args[0];
+			assert.equal(lastDiagnostics.length, 0);
 		});
 	});
 

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -11,6 +11,9 @@ describe('ProjectManager', () => {
 
 	let projectManager: ProjectManager;
 	let memfs: InMemoryFileSystem;
+	const diagnosticsPublisher = {
+		updateFileDiagnostics(diagnostics: any) { /* nop */ }
+	};
 
 	describe('getPackageName()', () => {
 		beforeEach(async () => {
@@ -22,7 +25,7 @@ describe('ProjectManager', () => {
 				['file:///subdirectory-with-tsconfig/src/dummy.ts', '']
 			]));
 			const updater = new FileSystemUpdater(localfs, memfs);
-			projectManager = new ProjectManager('/', memfs, updater, true);
+			projectManager = new ProjectManager('/', memfs, updater, diagnosticsPublisher, true);
 			await projectManager.ensureAllFiles();
 		});
 		it('should resolve package name when package.json is at the same level', () => {
@@ -43,7 +46,7 @@ describe('ProjectManager', () => {
 				['file:///src/dummy.ts', 'import * as somelib from "somelib";']
 			]));
 			const updater = new FileSystemUpdater(localfs, memfs);
-			projectManager = new ProjectManager('/', memfs, updater, true);
+			projectManager = new ProjectManager('/', memfs, updater, diagnosticsPublisher, true);
 		});
 		it('should ensure content for imports and references is fetched', async () => {
 			await projectManager.ensureReferencedFiles('file:///src/dummy.ts').toPromise();
@@ -60,7 +63,7 @@ describe('ProjectManager', () => {
 				['file:///src/jsconfig.json', '{}']
 			]));
 			const updater = new FileSystemUpdater(localfs, memfs);
-			projectManager = new ProjectManager('/', memfs, updater, true);
+			projectManager = new ProjectManager('/', memfs, updater, diagnosticsPublisher, true);
 			await projectManager.ensureAllFiles();
 		});
 		it('should resolve best configuration based on file name', () => {

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
 import * as ts from 'typescript';
-import { CompletionItemKind, LogMessageParams, TextDocumentIdentifier, TextDocumentItem } from 'vscode-languageserver';
+import { CompletionItemKind, LogMessageParams, PublishDiagnosticsParams, TextDocumentIdentifier, TextDocumentItem } from 'vscode-languageserver';
 import { SymbolKind } from 'vscode-languageserver-types';
 import { CacheGetParams, CacheSetParams, TextDocumentContentParams, WorkspaceFilesParams } from '../request-type';
 import { TypeScriptService, TypeScriptServiceFactory } from '../typescript-service';
@@ -49,6 +49,9 @@ export const initializeTypeScriptService = (createService: TypeScriptServiceFact
 			return Promise.resolve(null);
 		},
 		xcacheSet(params: CacheSetParams): any {
+			// noop
+		},
+		textDocumentPublishDiagnostics(diagnostics: PublishDiagnosticsParams): void {
 			// noop
 		}
 	});

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -27,6 +27,7 @@ import {
 	TextDocumentSyncKind
 } from 'vscode-languageserver';
 import { walkMostAST } from './ast';
+import { DiagnosticsPublisher } from './diagnostics';
 import { FileSystem, FileSystemUpdater, LocalFileSystem, RemoteFileSystem } from './fs';
 import { LanguageClient } from './lang-handler';
 import { Logger, LSPLogger } from './logging';
@@ -67,7 +68,6 @@ export type TypeScriptServiceFactory = (client: LanguageClient, options?: TypeSc
  * underscore.
  */
 export class TypeScriptService {
-
 	projectManager: pm.ProjectManager;
 
 	/**
@@ -137,7 +137,8 @@ export class TypeScriptService {
 			this.rootUri = params.rootUri || util.path2uri('', params.rootPath!);
 			this._initializeFileSystems(!this.options.strict && !(params.capabilities.xcontentProvider && params.capabilities.xfilesProvider));
 			this.updater = new FileSystemUpdater(this.fileSystem, this.inMemoryFileSystem);
-			this.projectManager = new pm.ProjectManager(this.root, this.inMemoryFileSystem, this.updater, !!this.options.strict, this.traceModuleResolution, this.logger);
+			const diagnosticsPublisher = new DiagnosticsPublisher(this.client);
+			this.projectManager = new pm.ProjectManager(this.root, this.inMemoryFileSystem, this.updater, diagnosticsPublisher, !!this.options.strict, this.traceModuleResolution, this.logger);
 			// Detect DefinitelyTyped
 			this.isDefinitelyTyped = (async () => {
 				try {

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -68,6 +68,7 @@ export type TypeScriptServiceFactory = (client: LanguageClient, options?: TypeSc
  * underscore.
  */
 export class TypeScriptService {
+
 	projectManager: pm.ProjectManager;
 
 	/**


### PR DESCRIPTION
This is a small implementation towards #162:
* ProjectManager exposes files to compiler via ProjectConfiguration in didOpen/didChange
* ProjectManager passes a DiagnosticsHandler to ProjectConfiguration
* ~~Expose `programSyncEvents` on ProjectConfiguration, triggered after compilation~~
* ~~DiagnosticsPublisher requests diagnostics on a synced program and publishes per file~~
* ProjectConfiguration passes TS file diagnostics to DiagnosticsHandler 
* ~~Basic tests~~
  * Unit tests for DiagnosticsPublisher
  * Existing functional tests expanded to test correct uri and content update handling

> Uncertainties:
> * It feels totally reasonable to expose a file to the compiler on didOpen, but for some reason this was not being done yet?
> * As discussed, VS Code stops showing diagnostics on broken code when you close the file. We would have to remove the file from the compiler to achieve consistent behaviour with VS Code.
> * Missing test scenarios for broken tsconfig, missing node modules, etc.
> * A minimum delay of 1 second feels good on instantly-compiling projects, but perhaps it should be the editor's job to delay showing feedback while the user is typing? Or should the didChange handler not trigger compiles immediately?

Thanks for the answers on these! Continuing conversation below.