### PR TITLE
Properly collect .d.ts files

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -932,7 +932,8 @@ export class ProjectConfiguration {
 		}
 
 		let changed = false;
-		for (const fileName of (this.getHost().expectedFilePaths || [])) {
+		for (const uri of this.fs.uris()) {
+			const fileName = util.uri2path(uri);
 			if (util.isGlobalTSFile(fileName) || (!util.isDependencyFile(fileName) && util.isDeclarationFile(fileName))) {
 				const sourceFile = program.getSourceFile(fileName);
 				if (!sourceFile) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -139,7 +139,7 @@ export function isPackageJsonFile(filename: string): boolean {
 
 const globalTSPatterns = [
 	/(^|\/)globals?\.d\.ts$/,
-	/node_modules\/\@types\/node\/.*/,
+	/node_modules\/(?:\@|%40)types\/node\/.*/,
 	/(^|\/)typings\/.*/,
 	/(^|\/)tsd\.d\.ts($|\/)/
 ];


### PR DESCRIPTION
- when adding basic files, searching for them project-wide instead of searching in expected files list. The reason is that files may be excluded by tsconfig.json rule
- when matching files against pattern need to remember that we can match both filenames and URIs