### PR TITLE
Add tracing spans around retrieving and publishing diagnostics

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,4 +1,4 @@
-import { Span } from 'opentracing/lib';
+import { Span } from 'opentracing';
 import * as ts from 'typescript';
 import { DiagnosticSeverity, PublishDiagnosticsParams } from 'vscode-languageserver';
 import { LanguageClient } from './lang-handler';
@@ -34,28 +34,33 @@ export class DiagnosticsPublisher implements DiagnosticsHandler {
 	 * @param diagnostics
 	 */
 	updateFileDiagnostics(diagnostics: ts.Diagnostic[], childOf = new Span()): void {
-		const span = childOf.tracer().startSpan('Publish diagnostics', { childOf });
+		const span = childOf.tracer().startSpan('Update file diagnostics', { childOf });
 
-		// categorize diagnostics by file
-		const diagnosticsByFile = this.groupByFile(diagnostics);
+		try {
+			// categorize diagnostics by file
+			const diagnosticsByFile = this.groupByFile(diagnostics);
 
-		// add empty diagnostics for fixed files, so client marks them as resolved
-		for (const file of this.problemFiles) {
-			if (!diagnosticsByFile.has(file)) {
-				diagnosticsByFile.set(file, []);
+			// add empty diagnostics for fixed files, so client marks them as resolved
+			for (const file of this.problemFiles) {
+				if (!diagnosticsByFile.has(file)) {
+					diagnosticsByFile.set(file, []);
+				}
 			}
-		}
-		this.problemFiles.clear();
+			this.problemFiles.clear();
 
-		// for each file: publish and set as problem file
-		for (const [file, diagnostics] of diagnosticsByFile) {
-			this.publishFileDiagnostics(file, diagnostics);
-			if (diagnostics.length > 0) {
-				this.problemFiles.add(file);
+			// for each file: publish and set as problem file
+			for (const [file, diagnostics] of diagnosticsByFile) {
+				this.publishFileDiagnostics(file, diagnostics);
+				if (diagnostics.length > 0) {
+					this.problemFiles.add(file);
+				}
 			}
+		} catch (err) {
+			span.setTag('error', true);
+			span.log({ 'event': 'error', 'error.object': err, 'message': err.message, 'stack': err.stack});
+		} finally {
+			span.finish();
 		}
-
-		span.finish();
 	}
 
 	/**

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -871,7 +871,10 @@ export class ProjectConfiguration {
 		}
 	}
 
-	updateDiagnostics(program: ts.Program, childOf = new Span()): void {
+	/**
+	 * Queries an updated program for diagnostics for updating the client.
+	 */
+	private updateDiagnostics(program: ts.Program, childOf = new Span()): void {
 		const span = childOf.tracer().startSpan('Update diagnostics', { childOf });
 		try {
 			const diagnostics = ts.getPreEmitDiagnostics(program);


### PR DESCRIPTION
Adds a sibling span to `getProgram()` for `ts.getPreEmitDiagnostics`.
A 3rd sibling is added when publishing file diagnostics.

I was unable to test this yet, but can do this later after looking at the diagnostics performance regressions.