### PR TITLE
Only request diagnostics for js/ts files outside node_modules

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -874,7 +874,7 @@ export class ProjectConfiguration {
 		try {
 			let diagnostics: ts.Diagnostic[] = [];
 			for (const file of program.getSourceFiles()) {
-				if (!file.fileName.includes('/node_modules/') && util.isJSTSFile(file.fileName)) {
+				if (!/[\/\\]node_modules[\/\\]/.test(file.fileName)) {
 					diagnostics = diagnostics.concat(ts.getPreEmitDiagnostics(program, file));
 				}
 			}

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -872,9 +872,14 @@ export class ProjectConfiguration {
 	private updateDiagnostics(program: ts.Program, childOf = new Span()): void {
 		const span = childOf.tracer().startSpan('Update diagnostics', { childOf });
 		try {
-			const diagnostics = ts.getPreEmitDiagnostics(program);
-			span.log({ event: 'result', result: diagnostics.length });
+			let diagnostics: ts.Diagnostic[] = [];
+			for (const file of program.getSourceFiles()) {
+				if (!file.fileName.includes('/node_modules/') && util.isJSTSFile(file.fileName)) {
+					diagnostics = diagnostics.concat(ts.getPreEmitDiagnostics(program, file));
+				}
+			}
 			this.diagnosticsHandler.updateFileDiagnostics(diagnostics, span);
+			span.log({ event: 'result', result: diagnostics.length });
 		} catch (err) {
 			span.setTag('error', true);
 			span.log({ 'event': 'error', 'error.object': err, 'message': err.message, 'stack': err.stack});


### PR DESCRIPTION
This removes the overhead of calling getSemanticDiagnostics on package / built-in declaration files after every compile (syncProgram).

* Javascript and Typescript files outside node_modules should still return diagnostics.
* Latency on tests and operations that require a compile should be drastically improved