### PR TITLE
Normalize URI encodings

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -6,7 +6,7 @@ import iterate from 'iterare';
 import { Span } from 'opentracing';
 import Semaphore from 'semaphore-async-await';
 import { InMemoryFileSystem } from './memfs';
-import { normalizeDir, path2uri, toUnixPath, uri2path } from './util';
+import { normalizeDir, normalizeUri, path2uri, toUnixPath, uri2path } from './util';
 
 export interface FileSystem {
 	/**
@@ -36,7 +36,7 @@ export class RemoteFileSystem implements FileSystem {
 	 */
 	async getWorkspaceFiles(base?: string, childOf = new Span()): Promise<Iterable<string>> {
 		return iterate(await this.client.workspaceXfiles({ base }, childOf))
-			.map(textDocument => textDocument.uri);
+			.map(textDocument => normalizeUri(textDocument.uri));
 	}
 
 	/**
@@ -69,7 +69,7 @@ export class LocalFileSystem implements FileSystem {
 		const files = await new Promise<string[]>((resolve, reject) => {
 			glob('*', { cwd: root, nodir: true, matchBase: true }, (err, matches) => err ? reject(err) : resolve(matches));
 		});
-		return iterate(files).map(file => baseUri + file.split('/').map(encodeURIComponent).join('/'));
+		return iterate(files).map(file => normalizeUri(baseUri + file));
 	}
 
 	async getTextDocumentContent(uri: string): Promise<string> {

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -6,7 +6,7 @@ import iterate from 'iterare';
 import { Span } from 'opentracing';
 import Semaphore from 'semaphore-async-await';
 import { InMemoryFileSystem } from './memfs';
-import { normalizeDir, normalizeUri, path2uri, toUnixPath, uri2path } from './util';
+import { normalizeDir, normalizeUri, path2uri, uriToLocalPath } from './util';
 
 export interface FileSystem {
 	/**
@@ -59,7 +59,7 @@ export class LocalFileSystem implements FileSystem {
 	 * Converts the URI to an absolute path
 	 */
 	protected resolveUriToPath(uri: string): string {
-		return toUnixPath(path.resolve(this.rootPath, uri2path(uri)));
+		return path.resolve(this.rootPath, uriToLocalPath(uri));
 	}
 
 	async getWorkspaceFiles(base?: string): Promise<Iterable<string>> {

--- a/src/test/fs.test.ts
+++ b/src/test/fs.test.ts
@@ -52,9 +52,6 @@ describe('fs.ts', () => {
 			});
 		});
 		describe('getTextDocumentContent()', () => {
-			it('should read files denoted by relative URI', async () => {
-				assert.equal(await fileSystem.getTextDocumentContent('tweedledee'), 'hi');
-			});
 			it('should read files denoted by absolute URI', async () => {
 				assert.equal(await fileSystem.getTextDocumentContent(baseUri + 'tweedledee'), 'hi');
 			});

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -228,7 +228,7 @@ export class TypeScriptService {
 	 * location of a symbol at a given text document position.
 	 */
 	textDocumentDefinition(params: TextDocumentPositionParams, span = new Span()): Observable<Location[]> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 
 		// Fetch files needed to resolve definition
 		return this.projectManager.ensureReferencedFiles(uri, undefined, undefined, span)
@@ -277,7 +277,7 @@ export class TypeScriptService {
 	 * know some information about it.
 	 */
 	textDocumentXdefinition(params: TextDocumentPositionParams, span = new Span()): Observable<SymbolLocationInformation[]> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 
 		// Ensure files needed to resolve SymbolLocationInformation are fetched
 		return this.projectManager.ensureReferencedFiles(uri, undefined, undefined, span)
@@ -326,7 +326,7 @@ export class TypeScriptService {
 	 * given text document position.
 	 */
 	textDocumentHover(params: TextDocumentPositionParams, span = new Span()): Observable<Hover> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 
 		// Ensure files needed to resolve hover are fetched
 		return this.projectManager.ensureReferencedFiles(uri, undefined, undefined, span)
@@ -373,7 +373,7 @@ export class TypeScriptService {
 	 * Returns all references to the symbol at the position in the own workspace, including references inside node_modules.
 	 */
 	textDocumentReferences(params: ReferenceParams, span = new Span()): Observable<Location[]> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 		// Ensure all files were fetched to collect all references
 		return Observable.from(this.projectManager.ensureOwnFiles(span))
 			.mergeMap(() => {
@@ -551,7 +551,7 @@ export class TypeScriptService {
 	 * in a given text document.
 	 */
 	textDocumentDocumentSymbol(params: DocumentSymbolParams, span = new Span()): Observable<SymbolInformation[]> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 
 		// Ensure files needed to resolve symbols are fetched
 		return this.projectManager.ensureReferencedFiles(uri, undefined, undefined, span)
@@ -742,7 +742,7 @@ export class TypeScriptService {
 	 * property filled in.
 	 */
 	textDocumentCompletion(params: TextDocumentPositionParams, span = new Span()): Observable<CompletionList> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 
 		// Ensure files needed to suggest completions are fetched
 		return this.projectManager.ensureReferencedFiles(uri, undefined, undefined, span)
@@ -793,7 +793,7 @@ export class TypeScriptService {
 	 * information at a given cursor position.
 	 */
 	textDocumentSignatureHelp(params: TextDocumentPositionParams, span = new Span()): Observable<SignatureHelp> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 
 		// Ensure files needed to resolve signature are fetched
 		return this.projectManager.ensureReferencedFiles(uri, undefined, undefined, span)
@@ -844,7 +844,7 @@ export class TypeScriptService {
 	 * to read the document's truth using the document's uri.
 	 */
 	async textDocumentDidOpen(params: DidOpenTextDocumentParams): Promise<void> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 		// Ensure files needed for most operations are fetched
 		await this.projectManager.ensureReferencedFiles(uri).toPromise();
 		this.projectManager.didOpen(uri, params.textDocument.text);
@@ -857,7 +857,7 @@ export class TypeScriptService {
 	 * and language ids.
 	 */
 	async textDocumentDidChange(params: DidChangeTextDocumentParams): Promise<void> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 		let text: string | undefined;
 		for (const change of params.contentChanges) {
 			if (change.range || change.rangeLength) {
@@ -900,7 +900,7 @@ export class TypeScriptService {
 	 * saved in the client.
 	 */
 	async textDocumentDidSave(params: DidSaveTextDocumentParams): Promise<void> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 
 		// Ensure files needed to suggest completions are fetched
 		await this.projectManager.ensureReferencedFiles(uri).toPromise();
@@ -913,7 +913,7 @@ export class TypeScriptService {
 	 * (e.g. if the document's uri is a file uri the truth now exists on disk).
 	 */
 	async textDocumentDidClose(params: DidCloseTextDocumentParams): Promise<void> {
-		const uri = params.textDocument.uri;
+		const uri = util.normalizeUri(params.textDocument.uri);
 
 		// Ensure files needed to suggest completions are fetched
 		await this.projectManager.ensureReferencedFiles(uri).toPromise();

--- a/src/util.ts
+++ b/src/util.ts
@@ -107,7 +107,10 @@ export function path2uri(root: string, file: string): string {
 	} else {
 		p = file;
 	}
-	p = toUnixPath(p).split('/').map((val, i) => i <= 1 && /^[a-z]:$/i.test(val) ? val : encodeURIComponent(val)).join('/');
+	if (/^[a-z]:[\\\/]/i.test(p)) {
+		p = '/' + p;
+	}
+	p = p.split(/[\\\/]/g).map((val, i) => i <= 1 && /^[a-z]:$/i.test(val) ? val : encodeURIComponent(val)).join('/');
 	return normalizeUri(ret + p);
 }
 
@@ -122,6 +125,14 @@ export function uri2path(uri: string): string {
 		uri = uri.split('/').map(decodeURIComponent).join('/');
 	}
 	return uri;
+}
+
+export function uriToLocalPath(uri: string): string {
+	uri = uri.substring('file://'.length);
+	if (/^\/[a-z]:\//i.test(uri)) {
+		uri = uri.substring(1);
+	}
+	return uri.split('/').map(decodeURIComponent).join(path.sep);
 }
 
 export function isLocalUri(uri: string): boolean {

--- a/src/util.ts
+++ b/src/util.ts
@@ -108,7 +108,7 @@ export function path2uri(root: string, file: string): string {
 		p = file;
 	}
 	p = toUnixPath(p).split('/').map((val, i) => i <= 1 && /^[a-z]:$/i.test(val) ? val : encodeURIComponent(val)).join('/');
-	return ret + p;
+	return normalizeUri(ret + p);
 }
 
 export function uri2path(uri: string): string {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as ts from 'typescript';
+import * as url from 'url';
 import { Position, Range, SymbolKind } from 'vscode-languageserver';
 import * as rt from './request-type';
 
@@ -76,6 +77,23 @@ export function convertStringtoSymbolKind(kind: string): SymbolKind {
 		// case 'external module name'
 		default: return SymbolKind.Variable;
 	}
+}
+
+/**
+ * Normalizes URI encoding by encoding _all_ special characters in the pathname
+ */
+export function normalizeUri(uri: string): string {
+	const parts = url.parse(uri);
+	if (!parts.pathname) {
+		return uri;
+	}
+	const pathParts = parts.pathname.split('/').map(segment => encodeURIComponent(decodeURIComponent(segment)));
+	// Decode Windows drive letter colon
+	if (/^[a-z]%3A$/i.test(pathParts[1])) {
+		pathParts[1] = decodeURIComponent(pathParts[1]);
+	}
+	parts.pathname = pathParts.join('/');
+	return url.format(parts);
 }
 
 export function path2uri(root: string, file: string): string {


### PR DESCRIPTION
This always ensures a URI like `file:///node_modules/@angular` is normalized to `file:///node_modules/%40angular`