### PR TITLE
Add follow to glob + test for npm linked packages

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -67,7 +67,7 @@ export class LocalFileSystem implements FileSystem {
 		const root = this.resolveUriToPath(base || path2uri('', this.rootPath));
 		const baseUri = path2uri('', normalizeDir(root)) + '/';
 		const files = await new Promise<string[]>((resolve, reject) => {
-			glob('*', { cwd: root, nodir: true, matchBase: true }, (err, matches) => err ? reject(err) : resolve(matches));
+			glob('*', { cwd: root, nodir: true, matchBase: true, follow: true }, (err, matches) => err ? reject(err) : resolve(matches));
 		});
 		return iterate(files).map(file => normalizeUri(baseUri + file));
 	}

--- a/src/test/fs.test.ts
+++ b/src/test/fs.test.ts
@@ -43,11 +43,7 @@ describe('fs.ts', () => {
 			await fs.writeFile(path.join(projectDir, '@types', 'diff', 'index.d.ts'), 'baz');
 
 			// global package is symolinked into project using npm link
-			if (process.platform === 'win32') {
-				await fs.symlink(somePackageDir, path.join(projectDir, 'node_modules', 'some_package'), 'junction');
-			} else {
-				await fs.symlink(somePackageDir, path.join(projectDir, 'node_modules', 'some_package'));
-			}
+			await fs.symlink(somePackageDir, path.join(projectDir, 'node_modules', 'some_package'), 'junction');
 			fileSystem = new LocalFileSystem(toUnixPath(projectDir));
 		});
 		after(async () => {

--- a/src/test/fs.test.ts
+++ b/src/test/fs.test.ts
@@ -20,15 +20,31 @@ describe('fs.ts', () => {
 			temporaryDir = await new Promise<string>((resolve, reject) => {
 				temp.mkdir('local-fs', (err: Error, dirPath: string) => err ? reject(err) : resolve(dirPath));
 			});
-			baseUri = path2uri('', temporaryDir) + '/';
-			await fs.mkdir(path.join(temporaryDir, 'foo'));
-			await fs.mkdir(path.join(temporaryDir, '@types'));
-			await fs.mkdir(path.join(temporaryDir, '@types', 'diff'));
-			await fs.writeFile(path.join(temporaryDir, 'tweedledee'), 'hi');
-			await fs.writeFile(path.join(temporaryDir, 'tweedledum'), 'bye');
-			await fs.writeFile(path.join(temporaryDir, 'foo', 'bar.ts'), 'baz');
-			await fs.writeFile(path.join(temporaryDir, '@types', 'diff', 'index.d.ts'), 'baz');
-			fileSystem = new LocalFileSystem(toUnixPath(temporaryDir));
+
+			// global packages contains a package
+			const globalPackagesDir = path.join(temporaryDir, 'node_modules');
+			const somePackageDir = path.join(globalPackagesDir, 'some_package');
+			await fs.mkdir(somePackageDir);
+			await fs.mkdir(path.join(somePackageDir, 'src'));
+			await fs.writeFile(path.join(somePackageDir, 'src', 'function.ts'), 'foo');
+
+			// the project dir
+			const projectDir = path.join(temporaryDir, 'project');
+			baseUri = path2uri('', projectDir) + '/';
+			await fs.mkdir(projectDir);
+			await fs.mkdir(globalPackagesDir);
+			await fs.mkdir(path.join(projectDir, 'foo'));
+			await fs.mkdir(path.join(projectDir, '@types'));
+			await fs.mkdir(path.join(projectDir, '@types', 'diff'));
+			await fs.mkdir(path.join(projectDir, 'node_modules'));
+			await fs.writeFile(path.join(projectDir, 'tweedledee'), 'hi');
+			await fs.writeFile(path.join(projectDir, 'tweedledum'), 'bye');
+			await fs.writeFile(path.join(projectDir, 'foo', 'bar.ts'), 'baz');
+			await fs.writeFile(path.join(projectDir, '@types', 'diff', 'index.d.ts'), 'baz');
+
+			// global package is symolinked into project using npm link
+			await fs.symlink(somePackageDir, path.join(projectDir, 'node_modules', 'some_package'));
+			fileSystem = new LocalFileSystem(toUnixPath(projectDir));
 		});
 		after(async () => {
 			await new Promise<void>((resolve, reject) => {
@@ -42,7 +58,8 @@ describe('fs.ts', () => {
 					baseUri + 'tweedledee',
 					baseUri + 'tweedledum',
 					baseUri + 'foo/bar.ts',
-					baseUri + '%40types/diff/index.d.ts'
+					baseUri + '%40types/diff/index.d.ts',
+					baseUri + 'node_modules/some_package/src/function.ts'
 				]);
 			});
 			it('should return all files under specific root', async () => {

--- a/src/test/fs.test.ts
+++ b/src/test/fs.test.ts
@@ -23,6 +23,7 @@ describe('fs.ts', () => {
 
 			// global packages contains a package
 			const globalPackagesDir = path.join(temporaryDir, 'node_modules');
+			await fs.mkdir(globalPackagesDir);
 			const somePackageDir = path.join(globalPackagesDir, 'some_package');
 			await fs.mkdir(somePackageDir);
 			await fs.mkdir(path.join(somePackageDir, 'src'));
@@ -32,7 +33,6 @@ describe('fs.ts', () => {
 			const projectDir = path.join(temporaryDir, 'project');
 			baseUri = path2uri('', projectDir) + '/';
 			await fs.mkdir(projectDir);
-			await fs.mkdir(globalPackagesDir);
 			await fs.mkdir(path.join(projectDir, 'foo'));
 			await fs.mkdir(path.join(projectDir, '@types'));
 			await fs.mkdir(path.join(projectDir, '@types', 'diff'));

--- a/src/test/fs.test.ts
+++ b/src/test/fs.test.ts
@@ -43,7 +43,11 @@ describe('fs.ts', () => {
 			await fs.writeFile(path.join(projectDir, '@types', 'diff', 'index.d.ts'), 'baz');
 
 			// global package is symolinked into project using npm link
-			await fs.symlink(somePackageDir, path.join(projectDir, 'node_modules', 'some_package'));
+			if (process.platform === 'win32') {
+				await fs.symlink(somePackageDir, path.join(projectDir, 'node_modules', 'some_package'), 'junction');
+			} else {
+				await fs.symlink(somePackageDir, path.join(projectDir, 'node_modules', 'some_package'));
+			}
 			fileSystem = new LocalFileSystem(toUnixPath(projectDir));
 		});
 		after(async () => {


### PR DESCRIPTION
For #218, this is to support developers who use npm link to make locally-developed packages available in another locally developed project. 
The existing configuration of 'glob' does not follow symlinks created by `npm link`.

Affects: Users running with LocalFs. 
Risk: `glob` notes the following on the use of `follow` on their documentation:
> Note that this can result in a lot of duplicate references in the presence of cyclic links.