### PR TITLE
Treat empty SymbolDescriptor query values as undefined

### DIFF
--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -465,11 +465,6 @@ export class TypeScriptService {
 					return this._workspaceSymbolDefinitelyTyped({ ...params, limit }, span);
 				}
 
-				// symbolQuery.containerKind is sometimes empty when symbol.containerKind = 'module'
-				if (symbolQuery && !symbolQuery.containerKind) {
-					symbolQuery.containerKind = undefined;
-				}
-
 				// A workspace/symol request searches all symbols in own code, but not in dependencies
 				const symbols = Observable.from(this.projectManager.ensureOwnFiles(span))
 					.mergeMap(() =>
@@ -522,10 +517,6 @@ export class TypeScriptService {
 		const symbolQuery = { ...params.symbol };
 		// Don't match PackageDescriptor on symbols
 		symbolQuery.package = undefined;
-		// symQuery.containerKind is sometimes empty when symbol.containerKind = 'module'
-		if (!symbolQuery.containerKind) {
-			symbolQuery.containerKind = undefined;
-		}
 
 		// Fetch all files in the package subdirectory
 		// All packages are in the types/ subdirectory

--- a/src/util.ts
+++ b/src/util.ts
@@ -224,7 +224,7 @@ export function defInfoToSymbolDescriptor(d: ts.DefinitionInfo): SymbolDescripto
  */
 export function isSymbolDescriptorMatch(query: Partial<SymbolDescriptor>, symbol: SymbolDescriptor): boolean {
 	for (const key of Object.keys(query)) {
-		if ((query as any)[key] === undefined) {
+		if (!(query as any)[key]) {
 			continue;
 		}
 		if (key === 'package') {


### PR DESCRIPTION
TS often returns empty strings for the undefined case. We hacked around this in two places for `containerName`, but not for `containerKind`, which caused some global j2d to fail. This consolidates it in a single place, the match function.