### PR TITLE
Respect PackageDescriptors in symbol queries

### DIFF
--- a/src/packages.ts
+++ b/src/packages.ts
@@ -1,5 +1,6 @@
 
 import { Observable, Subscription } from '@reactivex/rxjs';
+import { EventEmitter } from 'events';
 import { Span } from 'opentracing';
 import * as path from 'path';
 import * as url from 'url';
@@ -12,7 +13,7 @@ import { InMemoryFileSystem } from './memfs';
  * Schema of a package.json file
  */
 export interface PackageJson {
-	name: string;
+	name?: string;
 	version?: string;
 	typings?: string;
 	repository?: string | { type: string, url: string };
@@ -30,18 +31,53 @@ export interface PackageJson {
 	};
 }
 
-export class PackageManager implements Disposable {
+/**
+ * Matches:
+ *
+ *     /foo/node_modules/(bar)/index.d.ts
+ *     /foo/node_modules/bar/node_modules/(baz)/index.d.ts
+ *     /foo/node_modules/(@types/bar)/index.ts
+ */
+const NODE_MODULES_PACKAGE_NAME_REGEXP = /.*\/node_modules\/((?:@[^\/]+\/)?[^\/]+)\/.*$/;
+
+/**
+ * Returns the name of a package that a file is contained in
+ */
+export function extractNodeModulesPackageName(uri: string): string | undefined {
+	const match = decodeURIComponent(url.parse(uri).pathname || '').match(NODE_MODULES_PACKAGE_NAME_REGEXP);
+	return match ? match[1] : undefined;
+}
+
+/**
+ * Matches:
+ *
+ *     /foo/types/(bar)/index.d.ts
+ *     /foo/types/bar/node_modules/(baz)/index.d.ts
+ *     /foo/types/(@types/bar)/index.ts
+ */
+const DEFINITELY_TYPED_PACKAGE_NAME_REGEXP = /\/types\/((?:@[^\/]+\/)?[^\/]+)\/.*$/;
+
+/**
+ * Returns the name of a package that a file in DefinitelyTyped defines.
+ * E.g. `file:///foo/types/node/index.d.ts` -> `@types/node`
+ */
+export function extractDefinitelyTypedPackageName(uri: string): string | undefined {
+	const match = decodeURIComponent(url.parse(uri).pathname || '').match(DEFINITELY_TYPED_PACKAGE_NAME_REGEXP);
+	return match ? '@types/' + match[1] : undefined;
+}
+
+export class PackageManager extends EventEmitter implements Disposable {
 
 	/**
-	 * Set of package.json URIs _defined_ in the workspace.
-	 * This does not include package.jsons of dependencies and also not package.jsons that node_modules are vendored for.
-	 * This is updated as new package.jsons are discovered.
+	 * Map of package.json URIs _defined_ in the workspace to optional content.
+	 * Does not include package.jsons of dependencies.
+	 * Updated as new package.jsons are discovered.
 	 */
-	private packages = new Set<string>();
+	private packages = new Map<string, PackageJson | undefined>();
 
 	/**
 	 * The URI of the root package.json, if any.
-	 * This is updated as new package.jsons are discovered.
+	 * Updated as new package.jsons are discovered.
 	 */
 	public rootPackageJsonUri: string | undefined;
 
@@ -55,16 +91,29 @@ export class PackageManager implements Disposable {
 		private inMemoryFileSystem: InMemoryFileSystem,
 		private logger: Logger = new NoopLogger()
 	) {
+		super();
 		let rootPackageJsonLevel = Infinity;
 		// Find locations of package.jsons _not_ inside node_modules
 		this.subscriptions.add(
-			Observable.fromEvent<[string, string]>(inMemoryFileSystem, 'add', Array.of)
+			Observable.fromEvent<[string, string]>(this.inMemoryFileSystem, 'add', Array.of)
 				.subscribe(([uri, content]) => {
 					const parts = url.parse(uri);
 					if (!parts.pathname	|| !parts.pathname.endsWith('/package.json') || parts.pathname.includes('/node_modules/')) {
 						return;
 					}
-					this.packages.add(uri);
+					let parsed: PackageJson | undefined;
+					if (content) {
+						try {
+							parsed = JSON.parse(content);
+						} catch (err) {
+							logger.error(`Error parsing package.json:`, err);
+						}
+					}
+					// Don't override existing content with undefined
+					if (parsed || !this.packages.get(uri)) {
+						this.packages.set(uri, parsed);
+						this.emit('parsed', uri, parsed);
+					}
 					this.logger.log(`Found package ${uri}`);
 					// If the current root package.json is further nested than this one, replace it
 					const level = parts.pathname.split('/').length;
@@ -80,11 +129,17 @@ export class PackageManager implements Disposable {
 		this.subscriptions.unsubscribe();
 	}
 
+	/** Emitted when a new package.json was found and parsed */
+	on(event: 'parsed', listener: (uri: string, packageJson: PackageJson) => void): this;
+	on(event: string, listener: () => void): this {
+		return super.on(event, listener);
+	}
+
 	/**
 	 * Returns an Iterable for all package.jsons in the workspace
 	 */
 	packageJsonUris(): IterableIterator<string> {
-		return this.packages.values();
+		return this.packages.keys();
 	}
 
 	/**
@@ -96,8 +151,28 @@ export class PackageManager implements Disposable {
 		if (!packageJsonUri) {
 			return undefined;
 		}
-		await this.updater.ensure(packageJsonUri, span);
-		return JSON.parse(this.inMemoryFileSystem.getContent(packageJsonUri));
+		return await this.getPackageJson(packageJsonUri);
+	}
+
+	/**
+	 * Returns the parsed package.json of the passed URI
+	 *
+	 * @param uri URI of the package.json
+	 */
+	async getPackageJson(uri: string, span = new Span()): Promise<PackageJson> {
+		if (uri.includes('/node_modules/')) {
+			throw new Error(`Not an own package.json: ${uri}`);
+		}
+		let packageJson = this.packages.get(uri);
+		if (packageJson) {
+			return packageJson;
+		}
+		await this.updater.ensure(uri, span);
+		packageJson = this.packages.get(uri)!;
+		if (!packageJson) {
+			throw new Error(`Expected ${uri} to be registered in PackageManager`);
+		}
+		return packageJson;
 	}
 
 	/**

--- a/src/test/packages.test.ts
+++ b/src/test/packages.test.ts
@@ -1,0 +1,56 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { FileSystemUpdater } from '../fs';
+import { InMemoryFileSystem } from '../memfs';
+import { extractDefinitelyTypedPackageName, extractNodeModulesPackageName, PackageManager } from '../packages';
+import { MapFileSystem } from './fs-helpers';
+
+describe('packages.ts', () => {
+	describe('extractDefinitelyTypedPackageName()', () => {
+		it('should return the @types package name for a file in DefinitelyTyped', () => {
+			const packageName = extractDefinitelyTypedPackageName('file:///types/node/index.d.ts');
+			assert.equal(packageName, '@types/node');
+		});
+		it('should return undefined otherwise', () => {
+			const packageName = extractDefinitelyTypedPackageName('file:///package.json');
+			assert.strictEqual(packageName, undefined);
+		});
+	});
+	describe('extractNodeModulesPackageName()', () => {
+		it('should return the package name for a file in node_modules', () => {
+			const packageName = extractNodeModulesPackageName('file:///foo/node_modules/bar/baz/test.ts');
+			assert.equal(packageName, 'bar');
+		});
+		it('should return the package name for a file in a scoped package in node_modules', () => {
+			const packageName = extractNodeModulesPackageName('file:///foo/node_modules/@types/bar/baz/test.ts');
+			assert.equal(packageName, '@types/bar');
+		});
+		it('should return the package name for a file in nested node_modules', () => {
+			const packageName = extractNodeModulesPackageName('file:///foo/node_modules/bar/node_modules/baz/test.ts');
+			assert.equal(packageName, 'baz');
+		});
+		it('should return undefined otherwise', () => {
+			const packageName = extractNodeModulesPackageName('file:///foo/bar');
+			assert.strictEqual(packageName, undefined);
+		});
+	});
+	describe('PackageManager', () => {
+		it('should register new packages as they are added to InMemoryFileSystem', () => {
+			const memfs = new InMemoryFileSystem('/');
+			const localfs = new MapFileSystem(new Map());
+			const updater = new FileSystemUpdater(localfs, memfs);
+			const packageManager = new PackageManager(updater, memfs);
+
+			const listener = sinon.spy();
+			packageManager.on('parsed', listener);
+
+			memfs.add('file:///foo/package.json', '{}');
+
+			sinon.assert.calledOnce(listener);
+			sinon.assert.alwaysCalledWith(listener, 'file:///foo/package.json', {});
+
+			const packages = Array.from(packageManager.packageJsonUris());
+			assert.deepEqual(packages, ['file:///foo/package.json']);
+		});
+	});
+});


### PR DESCRIPTION
PackageDescriptors where not taken into account and returned for `workspace/xreferences` and `textDocument/xdefinition`.