### PR TITLE
Rename and code actions support

### DIFF
--- a/src/lang-handler.ts
+++ b/src/lang-handler.ts
@@ -3,6 +3,8 @@ import { FORMAT_TEXT_MAP, Span } from 'opentracing';
 import { inspect } from 'util';
 import { isReponseMessage, Message, NotificationMessage, RequestMessage, ResponseMessage } from 'vscode-jsonrpc/lib/messages';
 import {
+	ApplyWorkspaceEditParams,
+	ApplyWorkspaceEditResponse,
 	LogMessageParams,
 	PublishDiagnosticsParams,
 	TextDocumentIdentifier,
@@ -56,6 +58,13 @@ export interface LanguageClient {
 	 * @param params The diagnostics to send to the client
 	 */
 	textDocumentPublishDiagnostics(params: PublishDiagnosticsParams): void;
+
+	/**
+	 * Requests a set of text changes to be applied to documents in the workspace
+	 * Can occur as as a result of rename or executeCommand (code action).
+	 * @param params The edits to apply to the workspace
+	 */
+	workspaceApplyEdit(params: ApplyWorkspaceEditParams): Promise<ApplyWorkspaceEditResponse>;
 }
 
 /**
@@ -185,5 +194,14 @@ export class RemoteLanguageClient {
 	 */
 	textDocumentPublishDiagnostics(params: PublishDiagnosticsParams): void {
 		this.notify('textDocument/publishDiagnostics', params);
+	}
+
+	/**
+	 * Requests a set of text changes to be applied to documents in the workspace
+	 * Can occur as as a result of rename or executeCommand (code action).
+	 * @param params The edits to apply to the workspace
+	 */
+	workspaceApplyEdit(params: ApplyWorkspaceEditParams): Promise<ApplyWorkspaceEditResponse> {
+		return this.request('workspace/applyEdit', params).toPromise();
 	}
 }

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -622,6 +622,12 @@ export class InMemoryLanguageServiceHost implements ts.LanguageServiceHost {
 		return '' + this.projectVersion;
 	}
 
+	getNewLine(): string {
+		// Although this is optional, language service was sending edits with carriage returns if not specified.
+		// TODO: combine with the FormatOptions defaults.
+		return '\n';
+	}
+
 	/**
 	 * Incrementing current project version, telling TS compiler to invalidate internal data
 	 */

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -1,7 +1,7 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as ts from 'typescript';
-import { CompletionItemKind, CompletionList, TextDocumentIdentifier, TextDocumentItem } from 'vscode-languageserver';
+import { CompletionItemKind, CompletionList, DiagnosticSeverity, TextDocumentIdentifier, TextDocumentItem } from 'vscode-languageserver';
 import { Hover, Location, SignatureHelp, SymbolInformation, SymbolKind } from 'vscode-languageserver-types';
 import { LanguageClient, RemoteLanguageClient } from '../lang-handler';
 import { TextDocumentContentParams, WorkspaceFilesParams } from '../request-type';
@@ -15,7 +15,7 @@ const assert = chai.assert;
 /**
  * Enforcing strict mode to make tests pass on Windows
  */
-import { setStrict } from '../util';
+import { setStrict, uri2path } from '../util';
 setStrict(true);
 
 export interface TestContext {
@@ -52,6 +52,7 @@ export const initializeTypeScriptService = (createService: TypeScriptServiceFact
 		return Array.from(files.keys()).map(uri => ({ uri }));
 	});
 	this.client.xcacheGet.returns(null);
+	this.client.workspaceApplyEdit.returns(Promise.resolve({applied: true}));
 	this.service = createService(this.client);
 
 	await this.service.initialize({
@@ -2167,6 +2168,278 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				}
 			}).toArray().map(patches => apply(null, patches)).toPromise();
 			assert.notDeepEqual(result.items.length, []);
+		} as any);
+	} as any);
+
+	describe('textDocumentRename()', function (this: TestContext) {
+		beforeEach(initializeTypeScriptService(createService, rootUri, new Map([
+			[rootUri + 'package.json', '{ "name": "mypkg" }'],
+			[rootUri + 'a.ts', [
+				'class A {',
+				'	/** foo doc*/',
+				'    foo() {}',
+				'	/** bar doc*/',
+				'    bar(): number { return 1; }',
+				'	/** baz doc*/',
+				'    baz(): string { return ""; }',
+				'	/** qux doc*/',
+				'    qux: number;',
+				'}',
+				'const a = new A();',
+				'a.'
+			].join('\n')],
+			[rootUri + 'uses-import.ts', [
+				'import {d} from "./import"',
+				'const x = d();'
+			].join('\n')],
+			[rootUri + 'import.ts', 'export function d(): number { return 55; }']
+		])) as any);
+
+		afterEach(shutdownService as any);
+
+		it('handles rename on invalid symbol', async function (this: TestContext) {
+			let threw = false;
+			try {
+				await this.service.textDocumentRename({
+					textDocument: {
+						uri: rootUri + 'a.ts'
+					},
+					position: {
+						line: 0,
+						character: 1
+					},
+					newName: 'asdf'
+				});
+			} catch (e) {
+				assert.equal(e.message, 'Cannot rename: invalid symbol');
+				threw = true;
+			}
+			if (!threw) {
+				assert.fail('expected Error not thrown');
+			}
+		} as any);
+		it('handles rename on a class', async function (this: TestContext) {
+			const result = await this.service.textDocumentRename({
+				textDocument: {
+					uri: rootUri + 'a.ts'
+				},
+				position: {
+					line: 0,
+					character: 6
+				},
+				newName: 'B'
+			});
+			assert.deepEqual(result, {
+				changes: {
+					[rootUri + 'a.ts']: [{
+						newText: 'B',
+						range: {
+							end: {
+								character: 7,
+								line: 0
+							},
+							start: {
+								character: 6,
+								line: 0
+							}
+						}
+					}, {
+						newText: 'B',
+						range: {
+							end: {
+								character: 15,
+								line: 10
+							},
+							start: {
+								character: 14,
+								line: 10
+							}
+						}
+					}]
+				}
+			});
+		} as any);
+		it('handles rename on an imported function', async function (this: TestContext) {
+			const result = await this.service.textDocumentRename({
+				textDocument: {
+					uri: rootUri + 'import.ts'
+				},
+				position: {
+					line: 0,
+					character: 16
+				},
+				newName: 'f'
+			});
+			assert.deepEqual(result, {
+				changes: {
+					[rootUri + 'import.ts']: [{
+						newText: 'f',
+						range: {
+							end: {
+								character: 17,
+								line: 0
+							},
+							start: {
+								character: 16,
+								line: 0
+							}
+						}
+					}],
+					[rootUri + 'uses-import.ts']: [{
+						newText: 'f',
+						range: {
+							end: {
+								character: 9,
+								line: 0
+							},
+							start: {
+								character: 8,
+								line: 0
+							}
+						}
+					}, {
+						newText: 'f',
+						range: {
+							end: {
+								character: 11,
+								line: 1
+							},
+							start: {
+								character: 10,
+								line: 1
+							}
+						}
+					}]
+				}
+			});
+		} as any);
+	} as any);
+
+	describe('textDocumentCodeAction()', function (this: TestContext) {
+		beforeEach(initializeTypeScriptService(createService, rootUri, new Map([
+			[rootUri + 'package.json', '{ "name": "mypkg" }'],
+			[rootUri + 'a.ts', [
+				'class A {',
+				'  constructor() {',
+				'    missingThis = 33;',
+				'  }',
+				'}',
+				'const a = new A();'
+			].join('\n')]
+		])) as any);
+
+		afterEach(shutdownService as any);
+
+		it('suggests a missing this', async function (this: TestContext) {
+			await this.service.textDocumentDidOpen({
+				textDocument: {
+					uri: rootUri + 'a.ts',
+					languageId: 'typescript',
+					text: [
+						'class A {',
+						' missingThis: number;',
+						'  constructor() {',
+						'    missingThis = 33;',
+						'  }',
+						'}',
+						'const a = new A();'
+					].join('\n'),
+					version: 1
+				}
+			});
+
+			const firstDiagnostic = {
+				range: {
+					start: { line: 3, character: 4 },
+					end: { line: 3, character: 15 }
+				},
+				message: 'Cannot find name \'missingThis\'. Did you mean the instance member \'this.missingThis\'?',
+				severity: DiagnosticSeverity.Error,
+				code: 2663,
+				source: 'ts'
+			};
+			const actions = await this.service.textDocumentCodeAction({
+				textDocument: {
+					uri: rootUri + 'a.ts'
+				},
+				range: firstDiagnostic.range,
+				context: {
+					diagnostics: [firstDiagnostic]
+				}
+			});
+			assert.lengthOf(actions, 1);
+			assert.sameDeepMembers(actions, [
+				{
+					title: 'Add \'this.\' to unresolved variable.',
+					command: 'codeFix',
+					arguments: [
+						{
+							fileName: uri2path(rootUri + 'a.ts'),
+							textChanges: [
+								{
+									span: { start: 50, length: 15 },
+									newText: '\t  this.missingThis'
+								}
+							]
+						}
+					]
+				}
+			]);
+
+		} as any);
+	} as any);
+
+	describe('workspaceExecuteCommand()', function (this: TestContext) {
+		beforeEach(initializeTypeScriptService(createService, rootUri, new Map([
+			[rootUri + 'package.json', '{ "name": "mypkg" }'],
+			[rootUri + 'a.ts', [
+				'class A {',
+				'  constructor() {',
+				'    missingThis = 33;',
+				'  }',
+				'}',
+				'const a = new A();'
+			].join('\n')]
+		])) as any);
+
+		afterEach(shutdownService as any);
+
+		it('should return edits for a codeFix command', async function (this: TestContext) {
+			await this.service.workspaceExecuteCommand({
+				command: 'codeFix',
+				arguments: [
+					{
+						fileName: uri2path(rootUri + 'a.ts'),
+						textChanges: [
+							{
+								span: { start: 50, length: 15 },
+								newText: '\t  this.missingThis'
+							}
+						]
+					}
+				]
+			});
+			sinon.assert.called(this.client.workspaceApplyEdit);
+			const workspaceEdit = this.client.workspaceApplyEdit.lastCall.args[0];
+			assert.deepEqual(workspaceEdit, {
+				edit: {
+					changes: {
+						[rootUri + 'a.ts']: [{
+							newText: '\t  this.missingThis',
+							range: {
+								end: {
+									character: 9,
+									line: 5
+								},
+								start: {
+									character: 0,
+									line: 3
+								}
+							}
+						}]
+					}
+				}
+			});
 		} as any);
 	} as any);
 

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2209,7 +2209,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						character: 1
 					},
 					newName: 'asdf'
-				});
+				}).toArray().map(patches => apply(null, patches)).toPromise();
 			} catch (e) {
 				assert.equal(e.message, 'Cannot rename: invalid symbol');
 				threw = true;
@@ -2228,7 +2228,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					character: 6
 				},
 				newName: 'B'
-			});
+			}).toArray().map(patches => apply(null, patches)).toPromise();
 			assert.deepEqual(result, {
 				changes: {
 					[rootUri + 'a.ts']: [{
@@ -2269,7 +2269,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					character: 16
 				},
 				newName: 'f'
-			});
+			}).toArray().map(patches => apply(null, patches)).toPromise();
 			assert.deepEqual(result, {
 				changes: {
 					[rootUri + 'import.ts']: [{
@@ -2366,7 +2366,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				context: {
 					diagnostics: [firstDiagnostic]
 				}
-			});
+			}).toArray().map(patches => apply(null, patches)).toPromise();
 			assert.lengthOf(actions, 1);
 			assert.sameDeepMembers(actions, [
 				{
@@ -2405,7 +2405,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 		afterEach(shutdownService as any);
 
 		it('should return edits for a codeFix command', async function (this: TestContext) {
-			await this.service.workspaceExecuteCommand({
+			const result = await this.service.workspaceExecuteCommand({
 				command: 'codeFix',
 				arguments: [
 					{
@@ -2418,7 +2418,10 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						]
 					}
 				]
-			});
+			}).toArray().map(patches => apply(null, patches)).toPromise();
+
+			assert.isUndefined(result);
+
 			sinon.assert.called(this.client.workspaceApplyEdit);
 			const workspaceEdit = this.client.workspaceApplyEdit.lastCall.args[0];
 			assert.deepEqual(workspaceEdit, {

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -22,7 +22,7 @@ import {
 	Location,
 	MarkedString,
 	ParameterInformation,
-	Range as LSRange,
+	Range,
 	ReferenceParams,
 	RenameParams,
 	SignatureHelp,
@@ -1091,7 +1091,7 @@ export class TypeScriptService {
 		const start = ts.getLineAndCharacterOfPosition(sourceFile, textChange.span.start);
 		if (textChange.span.length) {
 			const end = ts.getLineAndCharacterOfPosition(sourceFile, textChange.span.start + textChange.span.length);
-			const range = LSRange.create(start, end);
+			const range = Range.create(start, end);
 			if (textChange.newText) {
 				return TextEdit.replace(range, textChange.newText);
 			} else {
@@ -1178,7 +1178,7 @@ export class TypeScriptService {
 	createRenameEdit(newText: string, sourceFile: ts.SourceFile, span: ts.TextSpan): TextEdit {
 		const start = ts.getLineAndCharacterOfPosition(sourceFile, span.start);
 		const end = ts.getLineAndCharacterOfPosition(sourceFile, span.start + span.length);
-		return TextEdit.replace(LSRange.create(start, end), newText);
+		return TextEdit.replace(Range.create(start, end), newText);
 	}
 
 	/**

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -6,6 +6,9 @@ import { Span } from 'opentracing';
 import * as path from 'path';
 import * as ts from 'typescript';
 import {
+	ApplyWorkspaceEditParams,
+	CodeActionParams,
+	Command,
 	CompletionItem,
 	CompletionItemKind,
 	CompletionList,
@@ -14,16 +17,21 @@ import {
 	DidOpenTextDocumentParams,
 	DidSaveTextDocumentParams,
 	DocumentSymbolParams,
+	ExecuteCommandParams,
 	Hover,
 	Location,
 	MarkedString,
 	ParameterInformation,
+	Range as LSRange,
 	ReferenceParams,
+	RenameParams,
 	SignatureHelp,
 	SignatureInformation,
 	SymbolInformation,
 	TextDocumentPositionParams,
-	TextDocumentSyncKind
+	TextDocumentSyncKind,
+	TextEdit,
+	WorkspaceEdit
 } from 'vscode-languageserver';
 import { walkMostAST } from './ast';
 import { convertTsDiagnostic } from './diagnostics';
@@ -205,6 +213,11 @@ export class TypeScriptService {
 				completionProvider: {
 					resolveProvider: false,
 					triggerCharacters: ['.']
+				},
+				codeActionProvider: true,
+				renameProvider: true,
+				executeCommandProvider: {
+					commands: []
 				},
 				xpackagesProvider: true
 			}
@@ -1002,6 +1015,161 @@ export class TypeScriptService {
 				};
 			})
 			.map(signatureHelp => ({ op: 'add', path: '', value: signatureHelp }) as AddPatch);
+	}
+
+	async textDocumentCodeAction(params: CodeActionParams, span = new Span()): Promise<Command[]> {
+		await this.projectManager.ensureReferencedFiles(params.textDocument.uri, undefined, undefined, span).toPromise();
+
+		const filePath = uri2path(params.textDocument.uri);
+		const configuration = this.projectManager.getConfiguration(filePath);
+		configuration.ensureBasicFiles(span);
+
+		const sourceFile = this._getSourceFile(configuration, filePath, span);
+		if (!sourceFile) {
+			throw new Error(`expected source file ${filePath} to exist in configuration`);
+		}
+
+		const start: number = ts.getPositionOfLineAndCharacter(sourceFile, params.range.start.line, params.range.start.character);
+		const end: number = ts.getPositionOfLineAndCharacter(sourceFile, params.range.end.line, params.range.end.character);
+		const errorCodes: number[] = [];
+		for (const diagnostic of params.context.diagnostics) {
+			if (typeof(diagnostic.code) === 'number') {
+				errorCodes.push(diagnostic.code);
+			}
+		}
+
+		// defaults from https://github.com/Microsoft/vscode/blob/master/tsfmt.json
+		// A formattingProvider could be implemented to read editorconfig etc.
+		const formatSettings: ts.FormatCodeSettings = {
+			indentSize: 4,
+			tabSize: 4,
+			newLineCharacter: '\n',
+			convertTabsToSpaces: false,
+			indentStyle: ts.IndentStyle.Smart,
+			insertSpaceAfterCommaDelimiter: true,
+			insertSpaceAfterSemicolonInForStatements: true,
+			insertSpaceBeforeAndAfterBinaryOperators: true,
+			insertSpaceAfterKeywordsInControlFlowStatements: true,
+			insertSpaceAfterFunctionKeywordForAnonymousFunctions: false,
+			insertSpaceBeforeFunctionParenthesis: false,
+			insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: false,
+			insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: false,
+			insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
+			insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
+			insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
+			placeOpenBraceOnNewLineForFunctions: false,
+			placeOpenBraceOnNewLineForControlBlocks: false
+		};
+
+		const fixes: ts.CodeAction[] = configuration.getService().getCodeFixesAtPosition(filePath, start, end, errorCodes, formatSettings);
+		if (!fixes) {
+			return [];
+		}
+
+		return fixes.map(fix => Command.create(fix.description, 'codeFix', ...fix.changes));
+	}
+
+	async workspaceExecuteCommand(params: ExecuteCommandParams, span = new Span()): Promise<void> {
+		switch (params.command) {
+			case 'codeFix':
+				if (params.arguments && params.arguments.length === 1) {
+					return this.executeCodeFixCommand(params.arguments, span);
+				} else {
+					throw new Error(`Command ${params.command} requires arguments`);
+				}
+			default:
+				throw new Error(`Unknown command ${params.command}`);
+		}
+	}
+
+	convertTextChange(textChange: ts.TextChange, sourceFile: ts.SourceFile): TextEdit {
+		const start = ts.getLineAndCharacterOfPosition(sourceFile, textChange.span.start);
+		if (textChange.span.length) {
+			const end = ts.getLineAndCharacterOfPosition(sourceFile, textChange.span.start + textChange.span.length);
+			const range = LSRange.create(start, end);
+			if (textChange.newText) {
+				return TextEdit.replace(range, textChange.newText);
+			} else {
+				return TextEdit.del(range);
+			}
+		} else {
+			return TextEdit.insert(start, textChange.newText);
+		}
+	}
+
+	async executeCodeFixCommand(fileTextChanges: ts.FileTextChanges[], span = new Span()): Promise<void> {
+		if (fileTextChanges.length === 0) {
+			throw new Error('No changes supplied for code fix command');
+		}
+
+		await this.projectManager.ensureOwnFiles(span);
+		const configuration = this.projectManager.getConfiguration(fileTextChanges[0].fileName);
+		configuration.ensureBasicFiles(span);
+		const fileToEdits: {[uri: string]: TextEdit[]} = {};
+		for (const change of fileTextChanges) {
+			const sourceFile = this._getSourceFile(configuration, change.fileName, span);
+			if (!sourceFile) {
+				throw new Error(`expected source file ${change.fileName} to exist in configuration`);
+			}
+			fileToEdits[path2uri(this.root, change.fileName)] =
+				change.textChanges.map(tc => this.convertTextChange(tc, sourceFile));
+		}
+
+		const params: ApplyWorkspaceEditParams = {
+			edit:  {
+				changes: fileToEdits
+			}
+		};
+		return this.client.workspaceApplyEdit(params).then(r => undefined);
+	}
+
+	async textDocumentRename(params: RenameParams, span = new Span()): Promise<WorkspaceEdit> {
+		await this.projectManager.ensureOwnFiles(span);
+
+		const filePath = uri2path(params.textDocument.uri);
+		const configuration = this.projectManager.getConfiguration(filePath);
+		configuration.ensureAllFiles(span);
+
+		const sourceFile = this._getSourceFile(configuration, filePath, span);
+		if (!sourceFile) {
+			throw new Error(`expected source file ${filePath} to exist in configuration`);
+		}
+
+		const position: number = ts.getPositionOfLineAndCharacter(sourceFile, params.position.line, params.position.character);
+
+		const renameInfo = configuration.getService().getRenameInfo(filePath, position);
+		if (!renameInfo.canRename) {
+			throw new Error('Cannot rename: invalid symbol');
+		}
+		const locations = configuration.getService().findRenameLocations(filePath, position, false, false);
+
+		return this.renameInLocations(configuration, params.newName, locations, span);
+	}
+
+	renameInLocations(configuration: ProjectConfiguration, newName: string, locations: ts.RenameLocation[], span: Span): WorkspaceEdit {
+		const changes: {[fileName: string]: TextEdit[]} = {};
+
+		for (const location of locations) {
+
+			const sourceFile = this._getSourceFile(configuration, location.fileName, span);
+			if (!sourceFile) {
+				throw new Error(`expected source file ${location.fileName} to exist in configuration`);
+			}
+			const fileUri = path2uri(this.root, location.fileName);
+
+			if (changes[fileUri]) {
+				changes[fileUri].push(this.createRenameEdit(newName, sourceFile, location.textSpan));
+			} else {
+				changes[fileUri] = [this.createRenameEdit(newName, sourceFile, location.textSpan)];
+			}
+		}
+		return { changes };
+	}
+
+	createRenameEdit(newText: string, sourceFile: ts.SourceFile, span: ts.TextSpan): TextEdit {
+		const start = ts.getLineAndCharacterOfPosition(sourceFile, span.start);
+		const end = ts.getLineAndCharacterOfPosition(sourceFile, span.start + span.length);
+		return TextEdit.replace(LSRange.create(start, end), newText);
 	}
 
 	/**


### PR DESCRIPTION
Adds 3 calls from the protocol around service-provided workspace edits:
* Rename -> returns edits to apply
* Code Actions -> returns 'codeFix' Commands when given a document, range and diagnostics
* ExecuteCommand -> applies 'codeFix' Command by calling `client.workspaceApplyEdit`

The following is unsolved:
- [ ] Should 'codeFix' be listed in the service's command capabilities?
- [ ] How should the service get workspace editing defaults (tab size, vs. spaces, newline)?

The following should be completed:
- [x] Initial review
- [ ] Improve test coverage
 
The following I would hope to do in a future PR:
* Support sending versioned document changes.



