### PR TITLE
Match SymbolDescriptors with a numeric score

### DIFF
--- a/src/test/util-test.ts
+++ b/src/test/util-test.ts
@@ -1,7 +1,40 @@
 import * as assert from 'assert';
-import { isGlobalTSFile, isSymbolDescriptorMatch } from '../util';
+import { getMatchingPropertyCount, isGlobalTSFile, isSymbolDescriptorMatch } from '../util';
 
 describe('util', () => {
+	describe('getSymbolSimilarity()', () => {
+		it('should return a score of 3 if 3 properties match', () => {
+			const score = getMatchingPropertyCount({
+				containerKind: undefined,
+				containerName: 'ts',
+				kind: 'interface',
+				name: 'Program',
+				package: undefined
+			}, {
+				containerKind: 'module',
+				containerName: 'ts',
+				kind: 'interface',
+				name: 'Program',
+				package: undefined
+			});
+			assert.equal(score, 3);
+		});
+		it('should return a score of 3 if 3 properties match deeply', () => {
+			const score = getMatchingPropertyCount({
+				name: 'a',
+				kind: 'class',
+				package: { name: 'mypkg' },
+				containerKind: undefined
+			}, {
+				kind: 'class',
+				name: 'a',
+				containerKind: '',
+				containerName: '',
+				package: { name: 'mypkg' }
+			});
+			assert.equal(score, 3);
+		});
+	});
 	describe('isSymbolDescriptorMatch()', () => {
 		it('should return true for a matching query', () => {
 			const matches = isSymbolDescriptorMatch({

--- a/src/test/util-test.ts
+++ b/src/test/util-test.ts
@@ -1,11 +1,10 @@
 import * as assert from 'assert';
-import { getMatchingPropertyCount, isGlobalTSFile, isSymbolDescriptorMatch } from '../util';
+import { getMatchScore, isGlobalTSFile, isSymbolDescriptorMatch } from '../util';
 
 describe('util', () => {
-	describe('getSymbolSimilarity()', () => {
-		it('should return a score of 3 if 3 properties match', () => {
-			const score = getMatchingPropertyCount({
-				containerKind: undefined,
+	describe('getMatchScore()', () => {
+		it('should return a score of 4 if 4 properties match', () => {
+			const score = getMatchScore({
 				containerName: 'ts',
 				kind: 'interface',
 				name: 'Program',
@@ -17,10 +16,10 @@ describe('util', () => {
 				name: 'Program',
 				package: undefined
 			});
-			assert.equal(score, 3);
+			assert.equal(score, 4);
 		});
-		it('should return a score of 2 if 2 properties match and one does not', () => {
-			const score = getMatchingPropertyCount({
+		it('should return a score of 4 if 4 properties match and 1 does not', () => {
+			const score = getMatchScore({
 				containerKind: '',
 				containerName: 'util',
 				kind: 'var',
@@ -33,10 +32,10 @@ describe('util', () => {
 				name: 'colors',
 				package: undefined
 			});
-			assert.equal(score, 2);
+			assert.equal(score, 4);
 		});
 		it('should return a score of 3 if 3 properties match deeply', () => {
-			const score = getMatchingPropertyCount({
+			const score = getMatchScore({
 				name: 'a',
 				kind: 'class',
 				package: { name: 'mypkg' },

--- a/src/test/util-test.ts
+++ b/src/test/util-test.ts
@@ -33,7 +33,7 @@ describe('util', () => {
 				name: 'colors',
 				package: undefined
 			});
-			assert.equal(score, 3);
+			assert.equal(score, 2);
 		});
 		it('should return a score of 3 if 3 properties match deeply', () => {
 			const score = getMatchingPropertyCount({

--- a/src/test/util-test.ts
+++ b/src/test/util-test.ts
@@ -19,6 +19,22 @@ describe('util', () => {
 			});
 			assert.equal(score, 3);
 		});
+		it('should return a score of 2 if 2 properties match and one does not', () => {
+			const score = getMatchingPropertyCount({
+				containerKind: '',
+				containerName: 'util',
+				kind: 'var',
+				name: 'colors',
+				package: undefined
+			}, {
+				containerKind: '',
+				containerName: '',
+				kind: 'var',
+				name: 'colors',
+				package: undefined
+			});
+			assert.equal(score, 3);
+		});
 		it('should return a score of 3 if 3 properties match deeply', () => {
 			const score = getMatchingPropertyCount({
 				name: 'a',

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -46,7 +46,7 @@ import {
 import {
 	convertStringtoSymbolKind,
 	defInfoToSymbolDescriptor,
-	getMatchingPropertyCount,
+	getMatchScore,
 	isLocalUri,
 	isSymbolDescriptorMatch,
 	normalizeUri,
@@ -1135,7 +1135,7 @@ export class TypeScriptService {
 						// Query by name
 						items = Observable.from(config.getService().getNavigateToItems(query.name || '', limit, undefined, false))
 							// Get a score how good the symbol matches the SymbolDescriptor (ignoring PackageDescriptor)
-							.map((item): [number, ts.NavigateToItem] => [getMatchingPropertyCount(queryWithoutPackage, {
+							.map((item): [number, ts.NavigateToItem] => [getMatchScore(queryWithoutPackage, {
 								kind: item.kind,
 								name: item.name,
 								containerKind: item.containerKind,

--- a/src/util.ts
+++ b/src/util.ts
@@ -221,6 +221,23 @@ export function defInfoToSymbolDescriptor(d: ts.DefinitionInfo): SymbolDescripto
 }
 
 /**
+ * Compares a SymbolDescriptor to a SymbolDescriptor query and returns a numeric score defining how well the query matches.
+ * Every property that matches increases the score by 1.
+ */
+export function getMatchingPropertyCount(query: any, symbol: any): number {
+	if (!query) {
+		return 0;
+	}
+	if (typeof query !== 'object' && query !== null) {
+		return +(query === symbol);
+	}
+	if (typeof symbol !== 'object' && symbol !== null) {
+		return 0;
+	}
+	return Object.keys(query).reduce((score, key) => score + getMatchingPropertyCount(query[key], symbol[key]), 0);
+}
+
+/**
  * Returns true if the passed SymbolDescriptor has at least the same properties as the passed partial SymbolDescriptor
  */
 export function isSymbolDescriptorMatch(query: Partial<SymbolDescriptor>, symbol: SymbolDescriptor): boolean {

--- a/src/util.ts
+++ b/src/util.ts
@@ -221,20 +221,20 @@ export function defInfoToSymbolDescriptor(d: ts.DefinitionInfo): SymbolDescripto
 }
 
 /**
- * Compares a SymbolDescriptor to a SymbolDescriptor query and returns a numeric score defining how well the query matches.
+ * Compares two values and returns a numeric score defining of how well they match.
  * Every property that matches increases the score by 1.
  */
-export function getMatchingPropertyCount(query: any, symbol: any): number {
-	if (!query) {
+export function getMatchScore(query: any, value: any): number {
+	// If query is a scalar value, compare by identity and return 0 or 1
+	if (typeof query !== 'object' || query === null) {
+		return +(query === value);
+	}
+	// If value is scalar, return no match
+	if (typeof value !== 'object' && value !== null) {
 		return 0;
 	}
-	if (typeof query !== 'object' && query !== null) {
-		return +(query === symbol);
-	}
-	if (typeof symbol !== 'object' && symbol !== null) {
-		return 0;
-	}
-	return Object.keys(query).reduce((score, key) => score + getMatchingPropertyCount(query[key], symbol[key]), 0);
+	// Both values are objects, compare each property and sum the scores
+	return Object.keys(query).reduce((score, key) => score + getMatchScore(query[key], value[key]), 0);
 }
 
 /**


### PR DESCRIPTION
This allows a `workspace/symbol` with SymbolDescriptor query to still match a symbol where e.g. all properties expect the containerName match as long as there is no better match.
`workspace/symbol` now streams results in the order of the match score (through the JSON Patch path index).