### PR TITLE
Use getNavigationTree for SymbolDescriptor queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "object-hash": "^1.1.8",
     "opentracing": "^0.14.0",
     "semaphore-async-await": "^1.5.1",
+    "string-similarity": "^1.1.0",
     "typescript": "2.3.2",
     "vscode-jsonrpc": "^3.1.0",
     "vscode-languageserver": "^3.1.0",

--- a/src/request-type.ts
+++ b/src/request-type.ts
@@ -71,17 +71,39 @@ export interface WorkspaceFilesParams {
  * metadata about the symbol.
  */
 export interface SymbolDescriptor {
-	kind: string;
-	name: string;
-	containerKind: string;
-	containerName: string;
-	package?: PackageDescriptor;
-}
 
-export namespace SymbolDescriptor {
-	export function create(kind: string, name: string, containerKind: string, containerName: string, pkg?: PackageDescriptor): SymbolDescriptor {
-		return { kind, name, containerKind, containerName, package: pkg };
-	}
+	/**
+	 * The kind of the symbol as a ts.ScriptElementKind
+	 */
+	kind: string;
+
+	/**
+	 * The name of the symbol as returned from TS
+	 */
+	name: string;
+
+	/**
+	 * The kind of the symbol the symbol is contained in, as a ts.ScriptElementKind.
+	 * Is an empty string if the symbol has no container.
+	 */
+	containerKind: string;
+
+	/**
+	 * The name of the symbol the symbol is contained in, as returned from TS.
+	 * Is an empty string if the symbol has no container.
+	 */
+	containerName: string;
+
+	/**
+	 * The file path of the file where the symbol is defined in, relative to the workspace rootPath.
+	 */
+	filePath: string;
+
+	/**
+	 * A PackageDescriptor describing the package this symbol belongs to.
+	 * Is `undefined` if the symbol does not belong to a package.
+	 */
+	package?: PackageDescriptor;
 }
 
 /*

--- a/src/request-type.ts
+++ b/src/request-type.ts
@@ -99,11 +99,6 @@ export interface WorkspaceSymbolParams {
 	 * A set of properties that describe the symbol to look up.
 	 */
 	symbol?: Partial<SymbolDescriptor>;
-
-	/**
-	 * The number of items to which to restrict the results set size.
-	 */
-	limit?: number;
 }
 
 /*

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -125,7 +125,7 @@ export function navigationTreeToSymbolDescriptor(tree: ts.NavigationTree, parent
 		symbolDescriptor.containerName = parent.text;
 	}
 	// If the symbol is an external module representing a file, set name to the file path
-	if (tree.kind === ts.ScriptElementKind.moduleElement && tree.text && /[\\\/]/.test(tree.text)) {
+	if (tree.kind === ts.ScriptElementKind.moduleElement && !tree.text) {
 		symbolDescriptor.name = '"' + filePath.replace(/(?:\.d)?\.tsx?$/, '') + '"';
 	}
 	// If the symbol itself is not a module and there is no containerKind

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -112,7 +112,7 @@ export function navigationTreeToSymbolInformation(tree: ts.NavigationTree, paren
 /**
  * Returns a SymbolDescriptor for a TypeScript NavigationTree node
  */
-export function navigationTreeToSymbolDescriptor(tree: ts.NavigationTree, parent: ts.NavigationTree | undefined, rootPath: string): SymbolDescriptor {
+export function navigationTreeToSymbolDescriptor(tree: ts.NavigationTree, parent: ts.NavigationTree | undefined, fileName: string, rootPath: string): SymbolDescriptor {
 	const symbolDescriptor: SymbolDescriptor = {
 		kind: tree.kind,
 		name: tree.text ? tree.text.replace(rootPath, '') : '',
@@ -121,8 +121,23 @@ export function navigationTreeToSymbolDescriptor(tree: ts.NavigationTree, parent
 	};
 	if (parent && navigationTreeIsSymbol(parent)) {
 		symbolDescriptor.containerKind = parent.kind;
-		symbolDescriptor.containerName = parent.text.replace(rootPath, '');
+		symbolDescriptor.containerName = parent.text;
 	}
+	// If the symbol is an external module representing a file, set name to the file path
+	if (tree.kind === ts.ScriptElementKind.moduleElement && tree.text && /[\\\/]/.test(tree.text)) {
+		symbolDescriptor.name = '"' + fileName.replace(/(?:\.d)?\.tsx?$/, '') + '"';
+	}
+	// If the symbol itself is not a module and there is no containerKind
+	// then the container is an external module named by the file name (without file extension)
+	if (symbolDescriptor.kind !== ts.ScriptElementKind.moduleElement && !symbolDescriptor.containerKind) {
+		if (!symbolDescriptor.containerName) {
+			symbolDescriptor.containerName = '"' + fileName.replace(/(?:\.d)?\.tsx?$/, '') + '"';
+		}
+		symbolDescriptor.containerKind = ts.ScriptElementKind.moduleElement;
+	}
+	// Make all paths that may occur in module names relative to the workspace rootPath
+	symbolDescriptor.name = symbolDescriptor.name.replace(rootPath, '');
+	symbolDescriptor.containerName = symbolDescriptor.containerName.replace(rootPath, '');
 	return symbolDescriptor;
 }
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -112,12 +112,13 @@ export function navigationTreeToSymbolInformation(tree: ts.NavigationTree, paren
 /**
  * Returns a SymbolDescriptor for a TypeScript NavigationTree node
  */
-export function navigationTreeToSymbolDescriptor(tree: ts.NavigationTree, parent: ts.NavigationTree | undefined, fileName: string, rootPath: string): SymbolDescriptor {
+export function navigationTreeToSymbolDescriptor(tree: ts.NavigationTree, parent: ts.NavigationTree | undefined, filePath: string, rootPath: string): SymbolDescriptor {
 	const symbolDescriptor: SymbolDescriptor = {
 		kind: tree.kind,
 		name: tree.text ? tree.text.replace(rootPath, '') : '',
 		containerKind: '',
-		containerName: ''
+		containerName: '',
+		filePath
 	};
 	if (parent && navigationTreeIsSymbol(parent)) {
 		symbolDescriptor.containerKind = parent.kind;
@@ -125,19 +126,20 @@ export function navigationTreeToSymbolDescriptor(tree: ts.NavigationTree, parent
 	}
 	// If the symbol is an external module representing a file, set name to the file path
 	if (tree.kind === ts.ScriptElementKind.moduleElement && tree.text && /[\\\/]/.test(tree.text)) {
-		symbolDescriptor.name = '"' + fileName.replace(/(?:\.d)?\.tsx?$/, '') + '"';
+		symbolDescriptor.name = '"' + filePath.replace(/(?:\.d)?\.tsx?$/, '') + '"';
 	}
 	// If the symbol itself is not a module and there is no containerKind
 	// then the container is an external module named by the file name (without file extension)
 	if (symbolDescriptor.kind !== ts.ScriptElementKind.moduleElement && !symbolDescriptor.containerKind) {
 		if (!symbolDescriptor.containerName) {
-			symbolDescriptor.containerName = '"' + fileName.replace(/(?:\.d)?\.tsx?$/, '') + '"';
+			symbolDescriptor.containerName = '"' + filePath.replace(/(?:\.d)?\.tsx?$/, '') + '"';
 		}
 		symbolDescriptor.containerKind = ts.ScriptElementKind.moduleElement;
 	}
 	// Make all paths that may occur in module names relative to the workspace rootPath
 	symbolDescriptor.name = symbolDescriptor.name.replace(rootPath, '');
 	symbolDescriptor.containerName = symbolDescriptor.containerName.replace(rootPath, '');
+	symbolDescriptor.filePath = symbolDescriptor.filePath.replace(rootPath, '');
 	return symbolDescriptor;
 }
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,0 +1,151 @@
+
+import * as ts from 'typescript';
+import { SymbolInformation, SymbolKind } from 'vscode-languageserver-types';
+import { isTypeScriptLibrary } from './memfs';
+import { SymbolDescriptor } from './request-type';
+import { path2uri, stripQuotes } from './util';
+
+/**
+ * Transforms definition's file name to URI. If definition belongs to the in-memory TypeScript library,
+ * returns git://github.com/Microsoft/TypeScript URL, otherwise returns file:// one
+ */
+export function locationUri(filePath: string): string {
+	if (isTypeScriptLibrary(filePath)) {
+		return 'git://github.com/Microsoft/TypeScript?v' + ts.version + '#lib/' + filePath.split(/[\/\\]/g).pop();
+	}
+	return path2uri('', filePath);
+}
+
+/**
+ * Returns an LSP SymbolInformation for a TypeScript NavigateToItem
+ */
+export function navigateToItemToSymbolInformation(item: ts.NavigateToItem, program: ts.Program): SymbolInformation {
+	const sourceFile = program.getSourceFile(item.fileName);
+	if (!sourceFile) {
+		throw new Error(`Source file ${item.fileName} does not exist`);
+	}
+	const symbolInformation: SymbolInformation = {
+		name: item.name,
+		kind: stringtoSymbolKind(item.kind),
+		location: {
+			uri: locationUri(sourceFile.fileName),
+			range: {
+				start: ts.getLineAndCharacterOfPosition(sourceFile, item.textSpan.start),
+				end: ts.getLineAndCharacterOfPosition(sourceFile, item.textSpan.start + item.textSpan.length)
+			}
+		}
+	};
+	if (item.containerName) {
+		symbolInformation.containerName = item.containerName;
+	}
+	return symbolInformation;
+}
+
+/**
+ * Returns an LSP SymbolKind for a TypeScript ScriptElementKind
+ */
+export function stringtoSymbolKind(kind: string): SymbolKind {
+	switch (kind) {
+		case 'module': return SymbolKind.Module;
+		case 'class': return SymbolKind.Class;
+		case 'local class': return SymbolKind.Class;
+		case 'interface': return SymbolKind.Interface;
+		case 'enum': return SymbolKind.Enum;
+		case 'enum member': return SymbolKind.Constant;
+		case 'var': return SymbolKind.Variable;
+		case 'local var': return SymbolKind.Variable;
+		case 'function': return SymbolKind.Function;
+		case 'local function': return SymbolKind.Function;
+		case 'method': return SymbolKind.Method;
+		case 'getter': return SymbolKind.Method;
+		case 'setter': return SymbolKind.Method;
+		case 'property': return SymbolKind.Property;
+		case 'constructor': return SymbolKind.Constructor;
+		case 'parameter': return SymbolKind.Variable;
+		case 'type parameter': return SymbolKind.Variable;
+		case 'alias': return SymbolKind.Variable;
+		case 'let': return SymbolKind.Variable;
+		case 'const': return SymbolKind.Constant;
+		case 'JSX attribute': return SymbolKind.Property;
+		// case 'script'
+		// case 'keyword'
+		// case 'type'
+		// case 'call'
+		// case 'index'
+		// case 'construct'
+		// case 'primitive type'
+		// case 'label'
+		// case 'directory'
+		// case 'external module name'
+		// case 'external module name'
+		default: return SymbolKind.Variable;
+	}
+}
+
+/**
+ * Returns an LSP SymbolInformation for a TypeScript NavigationTree node
+ */
+export function navigationTreeToSymbolInformation(tree: ts.NavigationTree, parent: ts.NavigationTree | undefined, sourceFile: ts.SourceFile): SymbolInformation {
+	const span = tree.spans[0];
+	if (!span) {
+		throw new Error('NavigationTree has no TextSpan');
+	}
+	const symbolInformation: SymbolInformation = {
+		name: tree.text,
+		kind: stringtoSymbolKind(tree.kind),
+		location: {
+			uri: locationUri(sourceFile.fileName),
+			range: {
+				start: ts.getLineAndCharacterOfPosition(sourceFile, span.start),
+				end: ts.getLineAndCharacterOfPosition(sourceFile, span.start + span.length)
+			}
+		}
+	};
+	if (parent && navigationTreeIsSymbol(parent)) {
+		symbolInformation.containerName = parent.text;
+	}
+	return symbolInformation;
+}
+
+/**
+ * Returns a SymbolDescriptor for a TypeScript NavigationTree node
+ */
+export function navigationTreeToSymbolDescriptor(tree: ts.NavigationTree, parent?: ts.NavigationTree): SymbolDescriptor {
+	// TODO remove quote stripping here and in defInfoToSymbolDescriptor
+	const symbolDescriptor: SymbolDescriptor = {
+		kind: tree.kind,
+		name: stripQuotes(tree.text),
+		containerKind: '',
+		containerName: ''
+	};
+	if (parent && navigationTreeIsSymbol(parent)) {
+		symbolDescriptor.containerKind = parent.kind;
+		symbolDescriptor.containerName = stripQuotes(parent.text);
+	}
+	return symbolDescriptor;
+}
+
+/**
+ * Walks a NaviationTree and emits items with a node and its parent node (if exists)
+ */
+export function *walkNavigationTree(tree: ts.NavigationTree, parent?: ts.NavigationTree): IterableIterator<{ tree: ts.NavigationTree, parent?: ts.NavigationTree }> {
+	yield { tree, parent };
+	for (const childItem of tree.childItems || []) {
+		yield* walkNavigationTree(childItem, tree);
+	}
+}
+
+/**
+ * Returns true if the NavigationTree node describes a proper symbol and not a e.g. a category like `<global>`
+ */
+export function navigationTreeIsSymbol(tree: ts.NavigationTree): boolean {
+	// Categories start with (, [, or <
+	if (/^[<\(\[]/.test(tree.text)) {
+		return false;
+	}
+	// Magic words
+	if (['default', 'constructor', 'new()'].indexOf(tree.text) >= 0) {
+		return false;
+	}
+	return true;
+}

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -192,7 +192,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						}
 					},
 					symbol: {
-						containerName: 'I',
+						containerName: 'd.I',
 						containerKind: '',
 						kind: 'property',
 						name: 'target'
@@ -916,7 +916,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					symbol: {
 						containerKind: '',
-						containerName: '',
+						containerName: '"node_modules/dep/dep"',
 						kind: 'var',
 						name: 'x'
 					}
@@ -1004,7 +1004,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						},
 						symbol: {
 							containerKind: '',
-							containerName: '',
+							containerName: '"node_modules/dep/dep"',
 							kind: 'var',
 							name: 'x'
 						}

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -506,8 +506,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 		describe('workspaceSymbol()', function (this: TestContext) {
 			it('should find a symbol by SymbolDescriptor query with name and package name', async function (this: TestContext) {
 				const result: SymbolInformation[] = await this.service.workspaceSymbol({
-					symbol: { name: 'resolveCallback', package: { name: '@types/resolve' } },
-					limit: 10
+					symbol: { name: 'resolveCallback', package: { name: '@types/resolve' } }
 				}).toArray().map(patches => apply(null, patches)).toPromise();
 				assert.deepEqual(result, [{
 					kind: SymbolKind.Variable,
@@ -529,10 +528,15 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 			} as any);
 			it('should find a symbol by SymbolDescriptor query with name, package name and empty containerKind', async function (this: TestContext) {
 				const result: SymbolInformation[] = await this.service.workspaceSymbol({
-					symbol: { name: 'resolveCallback', containerKind: '', package: { name: '@types/resolve' } },
-					limit: 10
+					symbol: {
+						name: 'resolveCallback',
+						containerKind: '',
+						package: {
+							name: '@types/resolve'
+						}
+					}
 				}).toArray().map(patches => apply(null, patches)).toPromise();
-				assert.deepEqual(result, [{
+				assert.deepEqual(result[0], {
 					kind: SymbolKind.Variable,
 					location: {
 						range: {
@@ -548,7 +552,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						uri: rootUri + 'types/resolve/index.d.ts'
 					},
 					name: 'resolveCallback'
-				}]);
+				});
 			} as any);
 		} as any);
 	} as any);
@@ -577,7 +581,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 							}
 						}
 					}).toArray().map(patches => apply(null, patches)).toPromise();
-					assert.deepEqual(result, [{
+					assert.deepEqual(result[0], {
 					kind: SymbolKind.Class,
 						location: {
 							range: {
@@ -593,14 +597,13 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 							uri: rootUri + 'a.ts'
 						},
 						name: 'a'
-					}]);
+					});
 				} as any);
 				it('should find a symbol by name, kind, package name and ignore package version', async function (this: TestContext) {
 					const result: SymbolInformation[] = await this.service.workspaceSymbol({
-						symbol: { name: 'a', kind: 'class', package: { name: 'mypkg', version: '203940234' } },
-						limit: 10
+						symbol: { name: 'a', kind: 'class', package: { name: 'mypkg', version: '203940234' } }
 					}).toArray().map(patches => apply(null, patches)).toPromise();
-					assert.deepEqual(result, [{
+					assert.deepEqual(result[0], {
 						kind: SymbolKind.Class,
 						location: {
 							range: {
@@ -616,7 +619,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 							uri: rootUri + 'a.ts'
 						},
 						name: 'a'
-					}]);
+					});
 				} as any);
 				it('should find a symbol by name', async function (this: TestContext) {
 					const result: SymbolInformation[] = await this.service.workspaceSymbol({
@@ -733,7 +736,25 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 							containerName: 'foo'
 						},
 						{
+							name: '"c"',
+							kind: SymbolKind.Module,
+							location: {
+								uri: rootUri + 'c.ts',
+								range: {
+									start: {
+										line: 0,
+										character: 0
+									},
+									end: {
+										line: 0,
+										character: 28
+									}
+								}
+							}
+						},
+						{
 							name: 'x',
+							containerName: '"c"',
 							kind: SymbolKind.Variable,
 							location: {
 								uri: rootUri + 'c.ts',
@@ -815,28 +836,6 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 									end: {
 										line: 0,
 										character: 76
-									}
-								}
-							}
-						}
-					]);
-				} as any);
-				it('should limit the result if a limit is passed', async function (this: TestContext) {
-					const result: SymbolInformation[] = await this.service.workspaceSymbol({ query: '', limit: 1 }).toArray().map(patches => apply(null, patches)).toPromise();
-					assert.deepEqual(result, [
-						{
-							name: 'a',
-							kind: SymbolKind.Class,
-							location: {
-								uri: rootUri + 'a.ts',
-								range: {
-									start: {
-										line: 0,
-										character: 0
-									},
-									end: {
-										line: 0,
-										character: 33
 									}
 								}
 							}
@@ -1729,6 +1728,8 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					]
 				});
 			} as any);
+			} as any);
+		describe('textDocumentDefinition()', function (this: TestContext) {
 			it('should resolve TS libraries to github URL', async function (this: TestContext) {
 				assert.deepEqual(await this.service.textDocumentDefinition({
 					textDocument: {

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -192,6 +192,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						}
 					},
 					symbol: {
+						filePath: 'd.ts',
 						containerName: 'd.I',
 						containerKind: '',
 						kind: 'property',
@@ -224,8 +225,9 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						}
 					},
 					symbol: {
-						containerName: '',
-						containerKind: '',
+						filePath: 'a.ts',
+						containerName: '"a"',
+						containerKind: 'module',
 						kind: 'const',
 						name: 'abc'
 					}
@@ -526,11 +528,11 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					name: 'resolveCallback'
 				}]);
 			} as any);
-			it('should find a symbol by SymbolDescriptor query with name, package name and empty containerKind', async function (this: TestContext) {
+			it('should find a symbol by SymbolDescriptor query with name, containerKind and package name', async function (this: TestContext) {
 				const result: SymbolInformation[] = await this.service.workspaceSymbol({
 					symbol: {
 						name: 'resolveCallback',
-						containerKind: '',
+						containerKind: 'module',
 						package: {
 							name: '@types/resolve'
 						}
@@ -850,6 +852,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				const result = await this.service.workspaceXreferences({ query: { name: 'foo', kind: 'method', containerName: 'a' } }).toArray().map(patches => apply(null, patches)).toPromise();
 				assert.deepEqual(result, [{
 					symbol: {
+						filePath: 'a.ts',
 						containerKind: '',
 						containerName: 'a',
 						name: 'foo',
@@ -874,6 +877,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				const result = await this.service.workspaceXreferences({ query: { name: 'foo', kind: 'method', containerName: 'a' }, hints: { dependeePackageName: 'mypkg' } }).toArray().map(patches => apply(null, patches)).toPromise();
 				assert.deepEqual(result, [{
 					symbol: {
+						filePath: 'a.ts',
 						containerKind: '',
 						containerName: 'a',
 						name: 'foo',
@@ -915,6 +919,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						uri: rootUri + 'c.ts'
 					},
 					symbol: {
+						filePath: 'node_modules/dep/dep.ts',
 						containerKind: '',
 						containerName: '"node_modules/dep/dep"',
 						kind: 'var',
@@ -927,8 +932,9 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				assert.deepEqual(result, [
 					{
 						symbol: {
-							containerName: '',
-							containerKind: '',
+							filePath: 'a.ts',
+							containerName: '"a"',
+							containerKind: 'module',
 							kind: 'class',
 							name: 'a'
 						},
@@ -948,6 +954,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					{
 						symbol: {
+							filePath: 'a.ts',
 							containerName: 'a',
 							containerKind: '',
 							name: 'foo',
@@ -969,8 +976,9 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					{
 						symbol: {
-							containerName: '',
-							containerKind: '',
+							filePath: 'a.ts',
+							containerName: '"a"',
+							containerKind: 'module',
 							name: 'i',
 							kind: 'const'
 						},
@@ -1003,6 +1011,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 							uri: rootUri + 'c.ts'
 						},
 						symbol: {
+							filePath: 'node_modules/dep/dep.ts',
 							containerKind: '',
 							containerName: '"node_modules/dep/dep"',
 							kind: 'var',
@@ -1011,8 +1020,9 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					{
 						symbol: {
-							containerName: '',
-							containerKind: '',
+							filePath: 'foo/b.ts',
+							containerName: '"foo/b"',
+							containerKind: 'module',
 							name: 'b',
 							kind: 'class'
 						},
@@ -1032,6 +1042,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					{
 						symbol: {
+							filePath: 'foo/b.ts',
 							containerName: 'b',
 							containerKind: '',
 							name: 'bar',
@@ -1053,6 +1064,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					{
 						symbol: {
+							filePath: 'foo/b.ts',
 							containerName: 'b',
 							containerKind: '',
 							name: 'baz',
@@ -1074,6 +1086,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					{
 						symbol: {
+							filePath: 'foo/b.ts',
 							containerName: 'b',
 							containerKind: '',
 							name: 'bar',
@@ -1095,8 +1108,9 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					{
 						symbol: {
-							containerName: '',
-							containerKind: '',
+							filePath: 'foo/b.ts',
+							containerName: '"foo/b"',
+							containerKind: 'module',
 							name: 'qux',
 							kind: 'function'
 						},

--- a/src/test/util-test.ts
+++ b/src/test/util-test.ts
@@ -25,6 +25,14 @@ describe('util', () => {
 			});
 			assert.equal(score, 4);
 		});
+		it('should return a score of 0.6 if a string property is 60% similar', () => {
+			const score = getMatchingPropertyCount({
+				filePath: 'lib/foo.d.ts'
+			}, {
+				filePath: 'src/foo.ts'
+			});
+			assert.equal(score, 0.6);
+		});
 		it('should return a score of 4 if 4 properties match and 1 does not', () => {
 			const score = getMatchingPropertyCount({
 				containerKind: '',
@@ -77,12 +85,14 @@ describe('util', () => {
 				containerName: 'ts',
 				kind: 'interface',
 				name: 'Program',
+				filePath: 'foo/bar.ts',
 				package: undefined
 			}, {
 				containerKind: 'module',
 				containerName: 'ts',
 				kind: 'interface',
 				name: 'Program',
+				filePath: 'foo/bar.ts',
 				package: undefined
 			});
 			assert.equal(matches, true);
@@ -92,12 +102,14 @@ describe('util', () => {
 				name: 'a',
 				kind: 'class',
 				package: { name: 'mypkg' },
+				filePath: 'foo/bar.ts',
 				containerKind: undefined
 			}, {
 				kind: 'class',
 				name: 'a',
 				containerKind: '',
 				containerName: '',
+				filePath: 'foo/bar.ts',
 				package: { name: 'mypkg' }
 			});
 			assert.equal(matches, true);

--- a/src/test/util-test.ts
+++ b/src/test/util-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { getMatchScore, isGlobalTSFile, isSymbolDescriptorMatch, JSONPTR } from '../util';
+import { getMatchingPropertyCount, getPropertyCount, isGlobalTSFile, isSymbolDescriptorMatch, JSONPTR } from '../util';
 
 describe('util', () => {
 	describe('JSONPTR', () => {
@@ -9,9 +9,9 @@ describe('util', () => {
 			assert.equal(pointer, '/changes/file:~1~1~1foo~1~0bar/-');
 		});
 	});
-	describe('getMatchScore()', () => {
+	describe('getMatchingPropertyCount()', () => {
 		it('should return a score of 4 if 4 properties match', () => {
-			const score = getMatchScore({
+			const score = getMatchingPropertyCount({
 				containerName: 'ts',
 				kind: 'interface',
 				name: 'Program',
@@ -26,7 +26,7 @@ describe('util', () => {
 			assert.equal(score, 4);
 		});
 		it('should return a score of 4 if 4 properties match and 1 does not', () => {
-			const score = getMatchScore({
+			const score = getMatchingPropertyCount({
 				containerKind: '',
 				containerName: 'util',
 				kind: 'var',
@@ -42,7 +42,7 @@ describe('util', () => {
 			assert.equal(score, 4);
 		});
 		it('should return a score of 3 if 3 properties match deeply', () => {
-			const score = getMatchScore({
+			const score = getMatchingPropertyCount({
 				name: 'a',
 				kind: 'class',
 				package: { name: 'mypkg' },
@@ -55,6 +55,19 @@ describe('util', () => {
 				package: { name: 'mypkg' }
 			});
 			assert.equal(score, 3);
+		});
+	});
+	describe('getPropertyCount()', () => {
+		it('should return the amount of leaf properties', () => {
+			const count = getPropertyCount({
+				name: 'a', // 1
+				kind: 'class', // 2
+				package: {
+					name: 'mypkg' // 3
+				},
+				containerKind: '' // 4
+			});
+			assert.equal(count, 4);
 		});
 	});
 	describe('isSymbolDescriptorMatch()', () => {

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1370,7 +1370,7 @@ export class TypeScriptService {
 									matchedNodes = nodes
 										// Get a score how good the symbol matches the SymbolDescriptor (ignoring PackageDescriptor)
 										.map(({ tree, parent }) => {
-											const symbolDescriptor = navigationTreeToSymbolDescriptor(tree, parent, this.root);
+											const symbolDescriptor = navigationTreeToSymbolDescriptor(tree, parent, sourceFile.fileName, this.root);
 											const score = getMatchingPropertyCount(queryWithoutPackage, symbolDescriptor);
 											return { score, tree, parent };
 										})

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -3,7 +3,6 @@ import iterate from 'iterare';
 import { AddPatch, OpPatch } from 'json-patch';
 import { toPairs } from 'lodash';
 import { Span } from 'opentracing';
-import * as path from 'path';
 import * as ts from 'typescript';
 import {
 	CodeActionParams,
@@ -51,10 +50,9 @@ import {
 	WorkspaceSymbolParams
 } from './request-type';
 import {
-	convertStringtoSymbolKind,
 	defInfoToSymbolDescriptor,
-	getMatchScore,
-	isLocalUri,
+	getMatchingPropertyCount,
+	getPropertyCount,
 	isSymbolDescriptorMatch,
 	JSONPTR,
 	normalizeUri,
@@ -67,6 +65,14 @@ import hashObject = require('object-hash');
 import { castArray, merge, noop, omit } from 'lodash';
 import * as url from 'url';
 import { extractDefinitelyTypedPackageName, extractNodeModulesPackageName, PackageJson, PackageManager } from './packages';
+import {
+	locationUri,
+	navigateToItemToSymbolInformation,
+	navigationTreeIsSymbol,
+	navigationTreeToSymbolDescriptor,
+	navigationTreeToSymbolInformation,
+	walkNavigationTree
+} from './symbols';
 
 export interface TypeScriptServiceOptions {
 	traceModuleResolution?: boolean;
@@ -341,7 +347,7 @@ export class TypeScriptService {
 						const start = ts.getLineAndCharacterOfPosition(sourceFile, definition.textSpan.start);
 						const end = ts.getLineAndCharacterOfPosition(sourceFile, definition.textSpan.start + definition.textSpan.length);
 						return {
-							uri: this._defUri(definition.fileName),
+							uri: locationUri(definition.fileName),
 							range: {
 								start,
 								end
@@ -393,7 +399,7 @@ export class TypeScriptService {
 				// Query TypeScript for references
 				return Observable.from(configuration.getService().getDefinitionAtPosition(fileName, offset) || [])
 					.mergeMap((definition: ts.DefinitionInfo): Observable<SymbolLocationInformation> => {
-						const definitionUri = this._defUri(definition.fileName);
+						const definitionUri = locationUri(definition.fileName);
 						// Get the PackageDescriptor
 						return this._getPackageDescriptor(definitionUri)
 							.map((packageDescriptor: PackageDescriptor | undefined): SymbolLocationInformation => {
@@ -629,10 +635,6 @@ export class TypeScriptService {
 	 */
 	workspaceSymbol(params: WorkspaceSymbolParams, span = new Span()): Observable<OpPatch> {
 
-		// Always return max. 50 results
-		// TODO stream 50 results, then re-query and stream the rest
-		const limit = Math.min(params.limit || Infinity, 50);
-
 		// Return cached result for empty query, if available
 		if (!params.query && !params.symbol && this.emptyQueryWorkspaceSymbols) {
 			return this.emptyQueryWorkspaceSymbols;
@@ -668,7 +670,7 @@ export class TypeScriptService {
 								throw new Error(`Could not find tsconfig for ${packageRootUri}`);
 							}
 							// Don't match PackageDescriptor on symbols
-							return this._getSymbolsInConfig(config, params.query || omit(params.symbol!, 'package'), limit, span);
+							return this._getSymbolsInConfig(config, omit(params.symbol!, 'package'), span);
 						});
 				}
 				// Regular workspace symbol search
@@ -689,15 +691,15 @@ export class TypeScriptService {
 							: observableFromIterable(this.projectManager.configurations())
 					)
 					// If PackageDescriptor is given, only search project with the matching package name
-					.mergeMap(config => this._getSymbolsInConfig(config, params.query || params.symbol, limit, span));
+					.mergeMap(config => this._getSymbolsInConfig(config, params.query || params.symbol, span));
 			})
-			// Filter symbols found in dependencies
-			.filter(([score, symbol]) => !symbol.location.uri.includes('/node_modules/'))
 			// Filter duplicate symbols
 			// There may be few configurations that contain the same file(s)
 			// or files from different configurations may refer to the same file(s)
 			.distinct(symbol => hashObject(symbol, { respectType: false } as any))
-			.take(limit)
+			// Limit the total amount of symbols returned for text or empty queries
+			// Higher limit for programmatic symbol queries because it could exclude results with a higher score
+			.take(params.symbol ? 1000 : 100)
 			// Find out at which index to insert the symbol to maintain sorting order by score
 			.map(([score, symbol]) => {
 				const index = scores.findIndex(s => s < score);
@@ -739,7 +741,9 @@ export class TypeScriptService {
 					return [];
 				}
 				const tree = config.getService().getNavigationTree(fileName);
-				return observableFromIterable(this._flattenNavigationTreeItem(tree, null, sourceFile));
+				return observableFromIterable(walkNavigationTree(tree))
+					.filter(({ tree, parent }) => navigationTreeIsSymbol(tree))
+					.map(({ tree, parent }) => navigationTreeToSymbolInformation(tree, parent, sourceFile));
 			})
 			.map(symbol => ({ op: 'add', path: '', value: symbol }) as AddPatch)
 			.startWith({ op: 'add', path: '', value: [] } as AddPatch);
@@ -814,7 +818,7 @@ export class TypeScriptService {
 										.map(symbol => ({
 											symbol,
 											reference: {
-												uri: this._defUri(source.fileName),
+												uri: locationUri(source.fileName),
 												range: {
 													start: ts.getLineAndCharacterOfPosition(source, node.pos + 1),
 													end: ts.getLineAndCharacterOfPosition(source, node.end)
@@ -1314,16 +1318,15 @@ export class TypeScriptService {
 	}
 
 	/**
-	 * Returns an Iterator for all symbols in a given config that match a given SymbolDescriptor
+	 * Returns an Observable for all symbols in a given config that match a given SymbolDescriptor or text query
 	 *
 	 * @param config The ProjectConfiguration to search
 	 * @param query A text or SymbolDescriptor query
-	 * @param limit An optional limit that is passed to TypeScript
-	 * @return Observable of SymbolInformations
+	 * @return Observable of [match score, SymbolInformation]
 	 */
-	protected _getSymbolsInConfig(config: ProjectConfiguration, query?: string | Partial<SymbolDescriptor>, limit = Infinity, childOf = new Span()): Observable<[number, SymbolInformation]> {
+	protected _getSymbolsInConfig(config: ProjectConfiguration, query?: string | Partial<SymbolDescriptor>, childOf = new Span()): Observable<[number, SymbolInformation]> {
 		const span = childOf.tracer().startSpan('Get symbols in config', { childOf });
-		span.addTags({ config: config.configFilePath, query, limit });
+		span.addTags({ config: config.configFilePath, query });
 
 		return (() => {
 			try {
@@ -1334,69 +1337,69 @@ export class TypeScriptService {
 					return Observable.empty();
 				}
 
-				if (query) {
-					let items: Observable<[number, ts.NavigateToItem]>;
-					if (typeof query === 'string') {
-						// Query by text query
-						items = Observable.from(config.getService().getNavigateToItems(query, limit, undefined, false))
-							// Same score for all
-							.map(item => [1, item]);
-					} else {
-						const queryWithoutPackage = omit(query, 'package') as SymbolDescriptor;
-						// Query by name
-						items = Observable.from(config.getService().getNavigateToItems(query.name || '', limit, undefined, false))
-							// Get a score how good the symbol matches the SymbolDescriptor (ignoring PackageDescriptor)
-							.map((item): [number, ts.NavigateToItem] => [getMatchScore(queryWithoutPackage, {
-								kind: item.kind,
-								name: item.name,
-								containerKind: item.containerKind,
-								containerName: item.containerName
-							}), item])
-							// If score === 0, no properties matched
-							.filter(([score, symbol]) => score > 0)
-							// If SymbolDescriptor matched, get package.json and match PackageDescriptor name
-							// TODO get and match full PackageDescriptor (version)
-							.mergeMap(([score, item]) => {
-								if (!query.package || !query.package.name) {
-									return [[score, item]];
-								}
-								const uri = path2uri('', item.fileName);
-								return Observable.from(this.packageManager.getClosestPackageJson(uri, span))
-									// If PackageDescriptor matches, increase score
-									.map((packageJson): [number, ts.NavigateToItem] => packageJson && packageJson.name === query.package!.name! ? [score + 1, item] : [score, item]);
-							});
-					}
-					return Observable.from(items)
-						// Map NavigateToItems to SymbolInformations
-						.map(([score, item]) => {
-							const sourceFile = program.getSourceFile(item.fileName);
-							if (!sourceFile) {
-								throw new Error(`Source file ${item.fileName} does not exist`);
-							}
-							const symbolInformation: SymbolInformation = {
-								name: item.name,
-								kind: convertStringtoSymbolKind(item.kind),
-								location: {
-									uri: this._defUri(item.fileName),
-									range: {
-										start: ts.getLineAndCharacterOfPosition(sourceFile, item.textSpan.start),
-										end: ts.getLineAndCharacterOfPosition(sourceFile, item.textSpan.start + item.textSpan.length)
-									}
-								}
-							};
-							if (item.containerName) {
-								symbolInformation.containerName = item.containerName;
-							}
-							return [score, symbolInformation] as [number, SymbolInformation];
-						})
-						.filter(([score, symbolInformation]) => isLocalUri(symbolInformation.location.uri));
-				} else {
-					// An empty query uses a different algorithm to iterate all files and aggregate the symbols per-file to get all symbols
-					// TODO make all implementations use this? It has the advantage of being streamable and cancellable
-					return observableFromIterable(this._getNavigationTreeItems(config))
+				if (typeof query === 'string') {
+					// Query by text query
+					// Limit the amount of symbols searched for text queries
+					return Observable.from(config.getService().getNavigateToItems(query, 100, undefined, false))
+						// Exclude dependencies and standard library
+						.filter(item => !isTypeScriptLibrary(item.fileName) && !item.fileName.includes('/node_modules/'))
 						// Same score for all
-						.map(symbol => [1, symbol])
-						.take(limit);
+						.map(item => [1, navigateToItemToSymbolInformation(item, program)] as [number, SymbolInformation]);
+				} else {
+					const queryWithoutPackage = query && omit(query, 'package') as SymbolDescriptor;
+					// Require at least 2 properties to match (or all if less provided)
+					const minScore = Math.min(2, getPropertyCount(query));
+					const program = config.getProgram(span);
+					if (!program) {
+						return Observable.empty();
+					}
+					const service = config.getService();
+					return Observable.from(program.getSourceFiles())
+						// Exclude dependencies and standard library
+						.filter(sourceFile => !isTypeScriptLibrary(sourceFile.fileName) && !sourceFile.fileName.includes('/node_modules/'))
+						.mergeMap(sourceFile => {
+							try {
+								const tree = service.getNavigationTree(sourceFile.fileName);
+								const nodes = observableFromIterable(walkNavigationTree(tree))
+									.filter(({ tree, parent }) => navigationTreeIsSymbol(tree));
+								let matchedNodes: Observable<{ score: number, tree: ts.NavigationTree, parent?: ts.NavigationTree }>;
+								if (!query) {
+									matchedNodes = nodes
+										.map(({ tree, parent }) => ({ score: 1, tree, parent }));
+								} else {
+									matchedNodes = nodes
+										// Get a score how good the symbol matches the SymbolDescriptor (ignoring PackageDescriptor)
+										.map(({ tree, parent }) => {
+											const symbolDescriptor = navigationTreeToSymbolDescriptor(tree, parent);
+											const score = getMatchingPropertyCount(queryWithoutPackage, symbolDescriptor);
+											return { score, tree, parent };
+										})
+										// If SymbolDescriptor matched, get package.json and match PackageDescriptor name
+										// TODO get and match full PackageDescriptor (version)
+										.mergeMap(({ score, tree, parent }) => {
+											if (!query.package || !query.package.name) {
+												return [{ score, tree, parent }];
+											}
+											const uri = path2uri('', sourceFile.fileName);
+											return Observable.from(this.packageManager.getClosestPackageJson(uri, span))
+												// If PackageDescriptor matches, increase score
+												.map(packageJson => {
+													if (packageJson && packageJson.name === query.package!.name!) {
+														score++;
+													}
+													return { score, tree, parent };
+												});
+										})
+										// Require a minimum score to not return thousands of results
+										.filter(({ score }) => score >= minScore);
+								}
+								return matchedNodes
+									.map(({ score, tree, parent }) => [score, navigationTreeToSymbolInformation(tree, parent, sourceFile)] as [number, SymbolInformation]);
+							} catch (e) {
+								this.logger.error('Could not get navigation tree for file', sourceFile.fileName);
+								return [];
+							}
+						});
 				}
 			} catch (err) {
 				return Observable.throw(err);
@@ -1409,90 +1412,6 @@ export class TypeScriptService {
 			.finally(() => {
 				span.finish();
 			});
-	}
-
-	/**
-	 * Transforms definition's file name to URI. If definition belongs to TypeScript library,
-	 * returns git://github.com/Microsoft/TypeScript URL, otherwise returns file:// one
-	 */
-	private _defUri(filePath: string): string {
-		if (isTypeScriptLibrary(filePath)) {
-			return 'git://github.com/Microsoft/TypeScript?v' + ts.version + '#lib/' + path.basename(filePath);
-		}
-		return path2uri(this.root, filePath);
-	}
-
-	/**
-	 * Fetches up to limit navigation bar items from given project, flattens them
-	 */
-	private _getNavigationTreeItems(configuration: ProjectConfiguration, span = new Span()): IterableIterator<SymbolInformation> {
-		const program = configuration.getProgram(span);
-		if (!program) {
-			return iterate([]);
-		}
-		return iterate(program.getSourceFiles())
-			// Exclude navigation items from TypeScript libraries
-			.filter(sourceFile => !isTypeScriptLibrary(sourceFile.fileName))
-			.map(sourceFile => {
-				try {
-					const tree = configuration.getService().getNavigationTree(sourceFile.fileName);
-					return this._flattenNavigationTreeItem(tree, null, sourceFile);
-				} catch (e) {
-					this.logger.error('Could not get navigation tree for file', sourceFile.fileName);
-					return [];
-				}
-			})
-			.flatten<SymbolInformation>();
-	}
-
-	/**
-	 * Flattens navigation tree by emitting acceptable NavigationTreeItems as SymbolInformations.
-	 * Some items (source files, modules) may be excluded
-	 */
-	private *_flattenNavigationTreeItem(item: ts.NavigationTree, parent: ts.NavigationTree | null, sourceFile: ts.SourceFile): IterableIterator<SymbolInformation> {
-		const acceptable = TypeScriptService.isAcceptableNavigationTreeItem(item);
-		if (acceptable) {
-			const span = item.spans[0];
-			const symbolInformation: SymbolInformation = {
-				name: item.text,
-				kind: convertStringtoSymbolKind(item.kind),
-				location: {
-					uri: this._defUri(sourceFile.fileName),
-					range: {
-						start: ts.getLineAndCharacterOfPosition(sourceFile, span.start),
-						end: ts.getLineAndCharacterOfPosition(sourceFile, span.start + span.length)
-					}
-				}
-			};
-			if (parent) {
-				symbolInformation.containerName = parent.text;
-			}
-			yield symbolInformation;
-		}
-		if (item.childItems) {
-			for (const childItem of item.childItems) {
-				yield* this._flattenNavigationTreeItem(childItem, acceptable ? item : null, sourceFile);
-			}
-		}
-	}
-
-	/**
-	 * @return true if navigation tree item is acceptable for inclusion into workspace/symbols
-	 */
-	private static isAcceptableNavigationTreeItem(item: ts.NavigationTree): boolean {
-		// modules and source files should be excluded
-		if ([ts.ScriptElementKind.moduleElement, 'sourcefile'].indexOf(item.kind) >= 0) {
-			return false;
-		}
-		// special items may start with ", (, [, or <
-		if (/^[<\(\[\"]/.test(item.text)) {
-			return false;
-		}
-		// magic words
-		if (['default', 'constructor', 'new()'].indexOf(item.text) >= 0) {
-			return false;
-		}
-		return true;
 	}
 }
 

--- a/src/typings/string-similarity.d.ts
+++ b/src/typings/string-similarity.d.ts
@@ -1,0 +1,4 @@
+
+declare module 'string-similarity' {
+	export function compareTwoStrings(a: string, b: string): number;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -193,7 +193,8 @@ export function defInfoToSymbolDescriptor(info: ts.DefinitionInfo, rootPath: str
 		kind: info.kind || '',
 		name: info.name || '',
 		containerKind: info.containerKind || '',
-		containerName: info.containerName || ''
+		containerName: info.containerName || '',
+		filePath: info.fileName
 	};
 	// If the symbol is an external module representing a file, set name to the file path
 	if (info.kind === ts.ScriptElementKind.moduleElement && info.name && /[\\\/]/.test(info.name)) {
@@ -201,15 +202,14 @@ export function defInfoToSymbolDescriptor(info: ts.DefinitionInfo, rootPath: str
 	}
 	// If the symbol itself is not a module and there is no containerKind
 	// then the container is an external module named by the file name (without file extension)
-	if (info.kind !== ts.ScriptElementKind.moduleElement && !info.containerKind) {
-		if (!info.containerName) {
-			symbolDescriptor.containerName = '"' + info.fileName.replace(/(?:\.d)?\.tsx?$/, '') + '"';
-		}
+	if (info.kind !== ts.ScriptElementKind.moduleElement && !info.containerKind && !info.containerName) {
+		symbolDescriptor.containerName = '"' + info.fileName.replace(/(?:\.d)?\.tsx?$/, '') + '"';
 		symbolDescriptor.containerKind = ts.ScriptElementKind.moduleElement;
 	}
 	// Make paths relative to root paths
 	symbolDescriptor.containerName = symbolDescriptor.containerName.replace(rootPath, '');
 	symbolDescriptor.name = symbolDescriptor.name.replace(rootPath, '');
+	symbolDescriptor.filePath = symbolDescriptor.filePath.replace(rootPath, '');
 	return symbolDescriptor;
 }
 


### PR DESCRIPTION
For modules, `name` is set to the file path of the module name. Before we passed this name to `getNavigateToItems()`, which didn't match it with anything. This changes it to get the NavigationTree from TypeScript (like we do for empty queries and documentSymbol queries) and then match with our own logic (string similarity).

Moves a lot of symbol logic from TypeScriptService and utils to its own module.
Changes `isAcceptableNavigationItem` to also report modules and sourcefiles (because we need to match them).
Adds a minimum score of 2 for all SymbolDescriptor queries (if >=2 properties were given in the query), which means at least 2 properties need to match. This acts as a natural limit. In turn, the total `limit` parameter is removed from workspace/symbol, because it conflicts with streaming (symbols with higher scores can come in after the limit was already exceeded).

Modules and SourceFiles are no longer excluded from symbols, this is essential for SymbolDescriptor queries to get the definition of a module.