### PR TITLE
Add test ensuring project files open without diagnostics

### DIFF
--- a/src/test/integration.test.ts
+++ b/src/test/integration.test.ts
@@ -38,7 +38,7 @@ describe.only('running against this project', () => {
 
 			assert.isAtLeast(fileContent.length, 1);
 
-			const resp = await service.textDocumentDidOpen({
+			await service.textDocumentDidOpen({
 				textDocument: {
 					uri: fileUri,
 					languageId: 'typescript',
@@ -50,6 +50,12 @@ describe.only('running against this project', () => {
 			{
 				diagnostics: [],
 				uri: fileUri
+			});
+
+			const resp = await service.textDocumentDidClose({
+				textDocument: {
+					uri: fileUri
+				}
 			});
 			return resp;
 		});

--- a/src/test/integration.test.ts
+++ b/src/test/integration.test.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai';
-import * as sinon from 'Sinon';
+import * as sinon from 'sinon';
 import glob = require('glob');
 import { RemoteLanguageClient } from '../lang-handler';
 import { TypeScriptService } from '../typescript-service';

--- a/src/test/integration.test.ts
+++ b/src/test/integration.test.ts
@@ -1,7 +1,7 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import glob = require('glob');
-import { RemoteLanguageClient } from '../lang-handler';
+import { LanguageClient, RemoteLanguageClient } from '../lang-handler';
 import { TypeScriptService } from '../typescript-service';
 import { path2uri } from '../util';
 import chaiAsPromised = require('chai-as-promised');
@@ -10,12 +10,13 @@ chai.use(chaiAsPromised);
 const assert = chai.assert;
 
 describe.only('running against this project', () => {
-	let client: any;
+	let client: { [K in keyof LanguageClient]: LanguageClient[K] & sinon.SinonStub };
 	let service: any;
 	let rootUri: string;
 
 	const rootPath = process.cwd();
 	const filePaths = glob.sync('src/*.ts');
+	const fs = new LocalFileSystem(rootPath);
 
 	before(async () => {
 		client = sinon.createStubInstance(RemoteLanguageClient);
@@ -33,10 +34,10 @@ describe.only('running against this project', () => {
 	for (const filePath of filePaths) {
 		it('should get no diagnostics on didOpen ' + filePath, async () => {
 			const fileUri = path2uri(rootPath, filePath);
-			const fs = new LocalFileSystem(rootPath);
 			const fileContent = await fs.getTextDocumentContent(fileUri);
 
 			assert.isAtLeast(fileContent.length, 1);
+			client.textDocumentPublishDiagnostics.resetHistory();
 
 			await service.textDocumentDidOpen({
 				textDocument: {

--- a/src/test/integration.test.ts
+++ b/src/test/integration.test.ts
@@ -1,0 +1,57 @@
+import * as chai from 'chai';
+import * as sinon from 'Sinon';
+import glob = require('glob');
+import { RemoteLanguageClient } from '../lang-handler';
+import { TypeScriptService } from '../typescript-service';
+import { path2uri } from '../util';
+import chaiAsPromised = require('chai-as-promised');
+import { LocalFileSystem } from '../fs';
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+describe.only('running against this project', () => {
+	let client: any;
+	let service: any;
+	let rootUri: string;
+
+	const rootPath = process.cwd();
+	const filePaths = glob.sync('src/*.ts');
+
+	before(async () => {
+		client = sinon.createStubInstance(RemoteLanguageClient);
+
+		rootUri = path2uri('', rootPath) + '/';
+
+		service = new TypeScriptService(client, {strict: false, traceModuleResolution: false});
+		await service.initialize({
+			processId: process.pid,
+			rootUri,
+			capabilities: {}
+		}).toPromise();
+	});
+
+	for (const filePath of filePaths) {
+		it('should get no diagnostics on didOpen ' + filePath, async () => {
+			const fileUri = path2uri(rootPath, filePath);
+			const fs = new LocalFileSystem(rootPath);
+			const fileContent = await fs.getTextDocumentContent(fileUri);
+
+			assert.isAtLeast(fileContent.length, 1);
+
+			const resp = await service.textDocumentDidOpen({
+				textDocument: {
+					uri: fileUri,
+					languageId: 'typescript',
+					version: 1,
+					text: fileContent
+				}
+			});
+			sinon.assert.calledWithExactly(client.textDocumentPublishDiagnostics,
+			{
+				diagnostics: [],
+				uri: fileUri
+			});
+			return resp;
+		});
+	}
+});


### PR DESCRIPTION
The language service should provide a diagnostic-free experience when opening compiled/linted content from this project.

Diagnostics can indicate type resolution issues which will affect hover/completion/jump-to-definition functionality.
Additionally, this test confirms that all unit-tested parts of the service work correctly together on windows/*nix platforms.
If possible, these tests should not count as coverage towards the project.

Only files from `src/*.ts` are tested for now, but `src/test/*.ts` should be added in the future