### PR TITLE
Only add expected declaration files, avoid generated declarations

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -11,6 +11,7 @@ import { InMemoryFileSystem } from './memfs';
 import { traceObservable, tracePromise, traceSync } from './tracing';
 import {
 	isConfigFile,
+	isDeclarationFile,
 	isGlobalTSFile,
 	isJSTSFile,
 	isPackageJsonFile,
@@ -889,22 +890,14 @@ export class ProjectConfiguration {
 			return;
 		}
 
-		// Add global declaration files from the whole workspace
+		// Add all global declaration files from the workspace and all declarations from the project
 		for (const uri of this.fs.uris()) {
 			const fileName = uri2path(uri);
-			if (isGlobalTSFile(fileName)) {
+			if (isGlobalTSFile(fileName) || (isDeclarationFile(fileName) && this.expectedFilePaths.has(toUnixPath(fileName)))) {
 				const sourceFile = program.getSourceFile(fileName);
 				if (!sourceFile) {
 					this.getHost().addFile(fileName);
 				}
-			}
-		}
-
-		// Add files that belong to the project according to tsconfig.json settings
-		for (const filePath of this.expectedFilePaths) {
-			const sourceFile = program.getSourceFile(filePath);
-			if (!sourceFile) {
-				this.getHost().addFile(filePath);
 			}
 		}
 		this.ensuredBasicFiles = true;

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -12,7 +12,6 @@ import { traceObservable, tracePromise, traceSync } from './tracing';
 import {
 	isConfigFile,
 	isDeclarationFile,
-	isDependencyFile,
 	isGlobalTSFile,
 	isJSTSFile,
 	isPackageJsonFile,
@@ -892,9 +891,14 @@ export class ProjectConfiguration {
 			return;
 		}
 
+		// paths have been forward-slashified by TS (see toUnixPath below)
+		// TODO: consider moving expectedFilePaths out of LanguageServiceHost?
+		const expectedFilePaths = this.getHost().expectedFilePaths;
+
 		for (const uri of this.fs.uris()) {
 			const fileName = uri2path(uri);
-			if (isGlobalTSFile(fileName) || (!isDependencyFile(fileName) && isDeclarationFile(fileName))) {
+			if (isGlobalTSFile(fileName) ||
+				(isDeclarationFile(fileName) && expectedFilePaths.includes(toUnixPath(fileName)))) {
 				const sourceFile = program.getSourceFile(fileName);
 				if (!sourceFile) {
 					this.getHost().addFile(fileName);


### PR DESCRIPTION
As discussed in #208, TS will publish diagnostics when it receives empty content when importing a module.

Normally, the content is guaranteed to be in place for file `src/typescript-service.ts` by `ensureReferencedFiles`, but TS was found to be requesting imports like 'vscode-jsonrpc' even when opening an import-free file like 'src/ast.ts'.

The imports were traced back to compiler-emitted declarations like `lib/connection.d.ts` which were exposed to TS by `ensureBasicFiles`.

This PR reduces the adding of declarations to only those matching the project configuration for *source* files.

Besides fixing the repo in #208, this PR allows the tests in #261 to pass and should improve the startup speed of the service on projects with emitted declarations.