### PR TITLE
Fix workspace/xreferences

### DIFF
--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -925,9 +925,9 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						uri: rootUri + 'c.ts'
 					},
 					symbol: {
-						filePath: 'node_modules/dep/dep.ts',
+						filePath: 'dep/dep.ts',
 						containerKind: '',
-						containerName: '"node_modules/dep/dep"',
+						containerName: '"dep/dep"',
 						kind: 'var',
 						name: 'x'
 					}
@@ -952,9 +952,9 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 						uri: rootUri + 'c.ts'
 					},
 					symbol: {
-						filePath: 'node_modules/dep/dep.ts',
+						filePath: 'dep/dep.ts',
 						containerKind: '',
-						containerName: '"node_modules/dep/dep"',
+						containerName: '"dep/dep"',
 						kind: 'var',
 						name: 'x',
 						package: {
@@ -1051,9 +1051,9 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 							uri: rootUri + 'c.ts'
 						},
 						symbol: {
-							filePath: 'node_modules/dep/dep.ts',
+							filePath: 'dep/dep.ts',
 							containerKind: '',
-							containerName: '"node_modules/dep/dep"',
+							containerName: '"dep/dep"',
 							kind: 'var',
 							name: 'x'
 						}

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -51,7 +51,6 @@ import {
 	WorkspaceSymbolParams
 } from './request-type';
 import {
-	defInfoToSymbolDescriptor,
 	getMatchingPropertyCount,
 	getPropertyCount,
 	JSONPTR,
@@ -66,6 +65,7 @@ import { castArray, merge, omit } from 'lodash';
 import * as url from 'url';
 import { extractDefinitelyTypedPackageName, extractNodeModulesPackageName, PackageJson, PackageManager } from './packages';
 import {
+	definitionInfoToSymbolDescriptor,
 	locationUri,
 	navigateToItemToSymbolInformation,
 	navigationTreeIsSymbol,
@@ -408,7 +408,7 @@ export class TypeScriptService {
 								if (!sourceFile) {
 									throw new Error(`Expected source file ${definition.fileName} to exist in configuration`);
 								}
-								const symbol = defInfoToSymbolDescriptor(definition, this.root);
+								const symbol = definitionInfoToSymbolDescriptor(definition, this.root);
 								if (packageDescriptor) {
 									symbol.package = packageDescriptor;
 								}
@@ -802,7 +802,7 @@ export class TypeScriptService {
 									// Find definition for node
 									return Observable.from(config.getService().getDefinitionAtPosition(source.fileName, node.pos + 1) || [])
 										.mergeMap(definition => {
-											const symbol = defInfoToSymbolDescriptor(definition, this.root);
+											const symbol = definitionInfoToSymbolDescriptor(definition, this.root);
 											// Check if SymbolDescriptor without PackageDescriptor matches
 											const score = getMatchingPropertyCount(queryWithoutPackage, symbol);
 											if (score < minScore || (params.query.package && !definition.fileName.includes(params.query.package.name))) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -148,35 +148,6 @@ export function isDeclarationFile(filename: string): boolean {
 }
 
 /**
- * Converts a ts.DefinitionInfo to a SymbolDescriptor
- */
-export function defInfoToSymbolDescriptor(info: ts.DefinitionInfo, rootPath: string): SymbolDescriptor {
-	const rootUnixPath = toUnixPath(rootPath);
-	const symbolDescriptor: SymbolDescriptor = {
-		kind: info.kind || '',
-		name: info.name || '',
-		containerKind: info.containerKind || '',
-		containerName: info.containerName || '',
-		filePath: info.fileName
-	};
-	// If the symbol is an external module representing a file, set name to the file path
-	if (info.kind === ts.ScriptElementKind.moduleElement && info.name && /[\\\/]/.test(info.name)) {
-		symbolDescriptor.name = '"' + info.fileName.replace(/(?:\.d)?\.tsx?$/, '') + '"';
-	}
-	// If the symbol itself is not a module and there is no containerKind
-	// then the container is an external module named by the file name (without file extension)
-	if (info.kind !== ts.ScriptElementKind.moduleElement && !info.containerKind && !info.containerName) {
-		symbolDescriptor.containerName = '"' + info.fileName.replace(/(?:\.d)?\.tsx?$/, '') + '"';
-		symbolDescriptor.containerKind = ts.ScriptElementKind.moduleElement;
-	}
-	// Make paths relative to root paths
-	symbolDescriptor.containerName = symbolDescriptor.containerName.replace(rootUnixPath, '');
-	symbolDescriptor.name = symbolDescriptor.name.replace(rootUnixPath, '');
-	symbolDescriptor.filePath = symbolDescriptor.filePath.replace(rootUnixPath, '');
-	return symbolDescriptor;
-}
-
-/**
  * Compares two values and returns a numeric score between 0 and 1 defining of how well they match.
  * E.g. if 2 of 4 properties in the query match, will return 2
  */


### PR DESCRIPTION
- Move SymbolDescriptor path normalization to function
- Move `defInfoToSymbolDescriptor` to symbols module
- Strip node_modules from SymbolDescriptor paths