### PR TITLE
Snippet support for autocompletion

### DIFF
--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -16,7 +16,7 @@ import { IBeforeAndAfterContext, ISuiteCallbackContext, ITestCallbackContext } f
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
-const defaultCapabilities: ClientCapabilities = {
+const DEFAULT_CAPABILITIES: ClientCapabilities = {
 	xcontentProvider: true,
 	xfilesProvider: true
 };
@@ -36,7 +36,7 @@ export interface TestContext {
  * @param createService A factory that creates the TypeScript service. Allows to test subclasses of TypeScriptService
  * @param files A Map from URI to file content of files that should be available in the workspace
  */
-export const initializeTypeScriptService = (createService: TypeScriptServiceFactory, rootUri: string, files: Map<string, string>, clientCapabilities?: ClientCapabilities) => async function (this: TestContext & IBeforeAndAfterContext): Promise<void> {
+export const initializeTypeScriptService = (createService: TypeScriptServiceFactory, rootUri: string, files: Map<string, string>, clientCapabilities: ClientCapabilities = DEFAULT_CAPABILITIES) => async function (this: TestContext & IBeforeAndAfterContext): Promise<void> {
 
 	// Stub client
 	this.client = sinon.createStubInstance(RemoteLanguageClient);
@@ -61,7 +61,7 @@ export const initializeTypeScriptService = (createService: TypeScriptServiceFact
 	await this.service.initialize({
 		processId: process.pid,
 		rootUri,
-		capabilities: clientCapabilities || defaultCapabilities
+		capabilities: clientCapabilities || DEFAULT_CAPABILITIES
 	}).toPromise();
 };
 
@@ -2149,7 +2149,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					}
 				}
 			},
-			...defaultCapabilities
+			...DEFAULT_CAPABILITIES
 		}));
 
 		afterEach(shutdownService);

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2163,7 +2163,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					line: 11,
 					character: 2
 				}
-			}).reduce<jsonpatch.Operation, CompletionList>(jsonpatch.applyReducer, null as any).toPromise();
+			}).reduce<Operation, CompletionList>(applyReducer, null as any).toPromise();
 			// * A snippet can define tab stops and placeholders with `$1`, `$2`
 			//  * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
 			//  * the end of the snippet. Placeholders with equal identifiers are linked,

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2125,7 +2125,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 
 	});
 
-	describe.only('textDocumentCompletion() with snippets', function (this: TestContext & ISuiteCallbackContext){
+	describe('textDocumentCompletion() with snippets', function (this: TestContext & ISuiteCallbackContext){
 		beforeEach(initializeTypeScriptService(createService, rootUri, new Map([
 			[rootUri + 'a.ts', [
 				'class A {',
@@ -2154,7 +2154,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 
 		afterEach(shutdownService);
 
-		it('shoudl produce completions with snippets if supported', async function (this: TestContext & ITestCallbackContext) {
+		it('should produce completions with snippets if supported', async function (this: TestContext & ITestCallbackContext) {
 			const result: CompletionList = await this.service.textDocumentCompletion({
 				textDocument: {
 					uri: rootUri + 'a.ts'
@@ -2262,6 +2262,8 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					label: 'bar',
 					kind: CompletionItemKind.Method,
 					documentation: 'bar doc',
+					insertText: 'bar',
+					insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0',
 					detail: '(method) A.bar(): number'
 				},
@@ -2269,6 +2271,8 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					label: 'baz',
 					kind: CompletionItemKind.Method,
 					documentation: 'baz doc',
+					insertText: 'baz',
+					insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0',
 					detail: '(method) A.baz(): string'
 				},
@@ -2276,6 +2280,8 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					label: 'foo',
 					kind: CompletionItemKind.Method,
 					documentation: 'foo doc',
+					insertText: 'foo',
+					insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0',
 					detail: '(method) A.foo(): void'
 				},
@@ -2283,6 +2289,8 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					label: 'qux',
 					kind: CompletionItemKind.Property,
 					documentation: 'qux doc',
+					insertText: 'qux',
+					insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0',
 					detail: '(property) A.qux: number'
 				}
@@ -2305,6 +2313,8 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					label: 'd',
 					kind: CompletionItemKind.Function,
 					documentation: 'd doc',
+					insertText: 'd',
+					insertTextFormat: InsertTextFormat.PlainText,
 					detail: 'function d(): void',
 					sortText: '0'
 				}]
@@ -2326,6 +2336,8 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					label: 'bar',
 					kind: CompletionItemKind.Interface,
 					documentation: 'bar doc',
+					insertText: 'bar',
+					insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0',
 					detail: 'interface foo.bar'
 				}]

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -176,7 +176,6 @@ export class TypeScriptService {
 
 	/**
 	 * Indicates if the client prefers completion results formatted as snippets.
-	 * @type {boolean}
 	 */
 	private supportsCompletionWithSnippets: boolean = false;
 
@@ -1034,9 +1033,7 @@ export class TypeScriptService {
 								} else {
 									const parameters = details.displayParts
 										.filter(p => p.kind === 'parameterName')
-										.map((p, index) => {
-											return '${' + `${index + 1}:${p.text}` + '}';
-										});
+										.map((p, index) => '${' + `${index + 1}:${p.text}` + '}'});
 									const paramString = parameters.join(', ');
 									item.insertText = details.name + `(${paramString})`;
 								}

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1006,13 +1006,6 @@ export class TypeScriptService {
 					return [];
 				}
 				function createSnippet(entry: ts.CompletionEntryDetails): string {
-					let index = 0;
-					const parameters = entry.displayParts
-						.filter(p => p.kind === 'parameterName')
-						.map(p => {
-							index++;
-							return '${' + `${index}:${p.text}` + '}';
-						});
 					if (entry.kind === 'property') {
 						return entry.name;
 					} else {

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1033,7 +1033,7 @@ export class TypeScriptService {
 								} else {
 									const parameters = details.displayParts
 										.filter(p => p.kind === 'parameterName')
-										.map((p, index) => '${' + `${index + 1}:${p.text}` + '}'});
+										.map((p, i) => '${' + `${i + 1}:${p.text}` + '}');
 									const paramString = parameters.join(', ');
 									item.insertText = details.name + `(${paramString})`;
 								}

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1009,6 +1009,13 @@ export class TypeScriptService {
 					if (entry.kind === 'property') {
 						return entry.name;
 					} else {
+						let index = 0;
+						const parameters = entry.displayParts
+							.filter(p => p.kind === 'parameterName')
+							.map(p => {
+								index++;
+								return '${' + `${index}:${p.text}` + '}';
+							});
 						const paramString = parameters.join(', ');
 						return entry.name + `(${paramString})`;
 					}


### PR DESCRIPTION
If the client sends `snippetSupport: true` in the textDocument/completion/completionItem capability, this PR adds support for responding with these fields set in CompletionItem:

```
insertTextFormat: InsertTextFormat.Snippet,
insertText: 'bar(${1:num})',
```

Both VS Code and Sublime Text support these snippets.
For clients not supporting snippets, CompletionItem will now contain
```
insertTextFormat: InsertTextFormat.PlainText
insertText: 'bar' // same as label
```