### PR TITLE
Don't send patches if client doesn't support streaming

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -251,17 +251,18 @@ export function registerLanguageHandler(messageEmitter: MessageEmitter, messageW
 		if (isRequestMessage(message)) {
 			const subscription = observable
 				.do(patch => {
-					span.log({ event: 'partialResult', patch });
-					// Send $/partialResult for partial result patches
-					// TODO only send if client supports it
-					messageWriter.write({
-						jsonrpc: '2.0',
-						method: '$/partialResult',
-						params: {
-							id: message.id,
-							patch: [patch]
-						} as PartialResultParams
-					});
+					if (streaming) {
+						span.log({ event: 'partialResult', patch });
+						// Send $/partialResult for partial result patches only if client supports it
+						messageWriter.write({
+							jsonrpc: '2.0',
+							method: '$/partialResult',
+							params: {
+								id: message.id,
+								patch: [patch]
+							} as PartialResultParams
+						});
+					}
 				})
 				// Build up final result for BC
 				// TODO send null if client declared streaming capability


### PR DESCRIPTION
Naïve fix for #329.
No benchmarking was done, but it prevents unneeded noise for clients who do not support streaming.