### PR TITLE
Add typeroots support

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -880,7 +880,7 @@ export class ProjectConfiguration {
 	private isExpectedDeclarationFile(fileName: string) {
 		if (isDeclarationFile(fileName)) {
 			return this.expectedFilePaths.has(toUnixPath(fileName)) ||
-					this.typeRoots.some(root => fileName.startsWith(root))
+					this.typeRoots.some(root => fileName.startsWith(root));
 		} else {
 			return false;
 		}

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -338,6 +338,10 @@ export class ProjectManager implements Disposable {
 		});
 	}
 
+	/**
+	 * Determines if a tsconfig/jsconfig needs additional declaration files loaded.
+	 * @param filePath
+	 */
 	isConfigDependency(filePath: string): boolean {
 		for (const config of this.configurations()) {
 			config.ensureConfigFile();
@@ -348,12 +352,13 @@ export class ProjectManager implements Disposable {
 		return false;
 	}
 
+	/**
+	 * Loads files determined by tsconfig to be needed into the file system
+	 */
 	ensureConfigDependencies(): Observable<never> {
 		return observableFromIterable(this.inMemoryFs.uris())
 			.filter(uri => this.isConfigDependency(uri2path(uri)))
-			.mergeMap(uri => this.updater.ensure(uri))
-			.publishReplay()
-			.refCount();
+			.mergeMap(uri => this.updater.ensure(uri));
 	}
 
 	/**
@@ -898,12 +903,9 @@ export class ProjectConfiguration {
 	 * @param fileName
 	 */
 	public isExpectedDeclarationFile(fileName: string) {
-		if (isDeclarationFile(fileName)) {
-			return this.expectedFilePaths.has(toUnixPath(fileName)) ||
-					this.typeRoots.some(root => fileName.startsWith(root));
-		} else {
-			return false;
-		}
+		return isDeclarationFile(fileName) &&
+				(this.expectedFilePaths.has(toUnixPath(fileName)) ||
+				this.typeRoots.some(root => fileName.startsWith(root)));
 	}
 
 	/**

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -341,7 +341,7 @@ export class ProjectManager implements Disposable {
 	isConfigDependency(filePath: string): boolean {
 		for (const config of this.configurations()) {
 			config.ensureConfigFile();
-			if (config.isExpectedDeclarationFile(toUnixPath(filePath))) {
+			if (config.isExpectedDeclarationFile(filePath)) {
 				return true;
 			}
 		}
@@ -862,8 +862,9 @@ export class ProjectConfiguration {
 		this.expectedFilePaths = new Set(configParseResult.fileNames);
 
 		const options = configParseResult.options;
+		const pathResolver = /[a-z]:\//i.test(base) ? path.win32 : path.posix;
 		this.typeRoots = options.typeRoots ?
-			options.typeRoots.map((r: string) => path.resolve(this.rootFilePath, r)) :
+			options.typeRoots.map((r: string) => pathResolver.resolve(this.rootFilePath, r)) :
 			[];
 
 		if (/(^|\/)jsconfig\.json$/.test(this.configFilePath)) {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -862,7 +862,7 @@ export class ProjectConfiguration {
 		this.expectedFilePaths = new Set(configParseResult.fileNames);
 
 		const options = configParseResult.options;
-		const pathResolver = /[a-z]:\//i.test(base) ? path.win32 : path.posix;
+		const pathResolver = /^[a-z]:\//i.test(base) ? path.win32 : path.posix;
 		this.typeRoots = options.typeRoots ?
 			options.typeRoots.map((r: string) => pathResolver.resolve(this.rootFilePath, r)) :
 			[];
@@ -894,8 +894,8 @@ export class ProjectConfiguration {
 	private ensuredBasicFiles = false;
 
 	/**
-	 * [isExpectedDeclarationFile description]
-	 * @param {string} fileName [description]
+	 * Determines if a fileName is a declaration file within expected files or type roots
+	 * @param fileName
 	 */
 	public isExpectedDeclarationFile(fileName: string) {
 		if (isDeclarationFile(fileName)) {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -371,7 +371,7 @@ export class ProjectManager implements Disposable {
 					this.ensuredConfigDependencies = undefined;
 				})
 				.publishReplay()
-				.refCount();
+				.refCount() as Observable<never>;
 			}
 			return this.ensuredConfigDependencies;
 		});

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -338,10 +338,10 @@ export class ProjectManager implements Disposable {
 		});
 	}
 
-	isConfigDependency(uri: string): boolean {
+	isConfigDependency(filePath: string): boolean {
 		for (const config of this.configurations()) {
 			config.ensureConfigFile();
-			if (config.isExpectedDeclarationFile(uri)) {
+			if (config.isExpectedDeclarationFile(toUnixPath(filePath))) {
 				return true;
 			}
 		}

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -735,7 +735,7 @@ export class ProjectConfiguration {
 	private expectedFilePaths = new Set<string>();
 
 	/**
-	 * List of resolved extra root directories to allow global typings to be loaded from.
+	 * List of resolved extra root directories to allow global type declaration files to be loaded from.
 	 */
 	private typeRoots: string[];
 
@@ -873,15 +873,17 @@ export class ProjectConfiguration {
 
 	private ensuredBasicFiles = false;
 
-	private isTypeRootDeclaration(path: string) {
-		if (isDeclarationFile(path)) {
-			for (const base of this.typeRoots) {
-				if (path.startsWith(base)) {
-					return true;
-				}
-			}
+	/**
+	 * [isExpectedDeclarationFile description]
+	 * @param {string} fileName [description]
+	 */
+	private isExpectedDeclarationFile(fileName: string) {
+		if (isDeclarationFile(fileName)) {
+			return this.expectedFilePaths.has(toUnixPath(fileName)) ||
+					this.typeRoots.some(root => fileName.startsWith(root))
+		} else {
+			return false;
 		}
-		return false;
 	}
 
 	/**
@@ -903,8 +905,7 @@ export class ProjectConfiguration {
 		for (const uri of this.fs.uris()) {
 			const fileName = uri2path(uri);
 			if (isGlobalTSFile(fileName) ||
-				this.isTypeRootDeclaration(fileName) ||
-				(isDeclarationFile(fileName) && this.expectedFilePaths.has(toUnixPath(fileName)))) {
+				this.isExpectedDeclarationFile(fileName)) {
 				const sourceFile = program.getSourceFile(fileName);
 				if (!sourceFile) {
 					this.getHost().addFile(fileName);

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -24,6 +24,28 @@ describe('ProjectManager', () => {
 		assert.isDefined(configs.find(config => config.configFilePath === '/foo/tsconfig.json'));
 	});
 
+	describe('ensureBasicFiles', () => {
+		beforeEach(async () => {
+			memfs = new InMemoryFileSystem('/');
+			const localfs = new MapFileSystem(new Map([
+				['file:///project/package.json', '{"name": "package-name-1"}'],
+				['file:///project/tsconfig.json', '{ "compilerOptions": { "typeRoots": ["../types"]} }'],
+				['file:///project/file.ts', 'console.log(GLOBALCONSTANT);'],
+				['file:///types/types.d.ts', 'declare var GLOBALCONSTANT=1;']
+
+			]));
+			const updater = new FileSystemUpdater(localfs, memfs);
+			projectManager = new ProjectManager('/', memfs, updater, true);
+		});
+		it('loads files from typeRoots', async () => {
+			await projectManager.ensureReferencedFiles('file:///project/file.ts').toPromise();
+			projectManager.invalidateModuleStructure();
+			await projectManager.ensureModuleStructure().toPromise();
+			memfs.getContent('file:///project/file.ts');
+			memfs.getContent('file:///types/types.d.ts');
+		});
+	});
+
 	describe('getPackageName()', () => {
 		beforeEach(async () => {
 			memfs = new InMemoryFileSystem('/');

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -39,8 +39,6 @@ describe('ProjectManager', () => {
 		});
 		it('loads files from typeRoots', async () => {
 			await projectManager.ensureReferencedFiles('file:///project/file.ts').toPromise();
-			projectManager.invalidateModuleStructure();
-			await projectManager.ensureModuleStructure().toPromise();
 			memfs.getContent('file:///project/file.ts');
 			memfs.getContent('file:///types/types.d.ts');
 		});


### PR DESCRIPTION
On codebases that rely on type roots for distributing extra declaration files, this code should prevent diagnostics about missing types and improve completions/hovers/etc.

To do: 
- [x] Fix lint error
- [x] Add test(s)