### PR TITLE
Switch to resolving expensive completionItem details

### DIFF
--- a/src/request-type.ts
+++ b/src/request-type.ts
@@ -234,3 +234,30 @@ export interface PartialResultParams {
 	 */
 	patch: Operation[];
 }
+
+/**
+ * Restriction on vscode's CompletionItem interface
+ */
+export interface CompletionItem extends vscode.CompletionItem {
+	data?: CompletionItemData;
+}
+
+/**
+ * The necessary fields for a completion item details to be resolved by typescript
+ */
+export interface CompletionItemData {
+	/**
+	 * The document from which the completion was requested
+	 */
+	uri: string;
+
+	/**
+	 * The offset into the document at which the completion was requested
+	 */
+	offset: number;
+
+	/**
+	 * The name field from typescript's returned completion entry
+	 */
+	entryName: string;
+}

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -5,7 +5,7 @@ import { applyReducer, Operation } from 'fast-json-patch';
 import { IBeforeAndAfterContext, ISuiteCallbackContext, ITestCallbackContext } from 'mocha';
 import * as sinon from 'sinon';
 import * as ts from 'typescript';
-import { CompletionItemKind, CompletionList, DiagnosticSeverity, InsertTextFormat, TextDocumentIdentifier, TextDocumentItem, WorkspaceEdit } from 'vscode-languageserver';
+import { CompletionItemKind, CompletionList, DiagnosticSeverity, InsertTextFormat, TextDocumentIdentifier, TextDocumentItem, WorkspaceEdit, CompletionItem } from 'vscode-languageserver';
 import { Command, Diagnostic, Hover, Location, SignatureHelp, SymbolInformation, SymbolKind } from 'vscode-languageserver-types';
 import { LanguageClient, RemoteLanguageClient } from '../lang-handler';
 import { DependencyReference, PackageInformation, ReferenceInformation, TextDocumentContentParams, WorkspaceFilesParams } from '../request-type';
@@ -2169,44 +2169,21 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 			//  * the end of the snippet. Placeholders with equal identifiers are linked,
 			//  * that is typing in one will update others too.
 			assert.equal(result.isIncomplete, false);
-			assert.sameDeepMembers(result.items, [
-				{
-					label: 'bar',
-					kind: CompletionItemKind.Method,
-					documentation: 'bar doc',
-					sortText: '0',
-					insertTextFormat: InsertTextFormat.Snippet,
-					insertText: 'bar(${1:num})',
-					detail: '(method) A.bar(num: number): number'
-				},
-				{
-					label: 'baz',
-					kind: CompletionItemKind.Method,
-					documentation: 'baz doc',
-					sortText: '0',
-					insertTextFormat: InsertTextFormat.Snippet,
-					insertText: 'baz(${1:num})',
-					detail: '(method) A.baz(num: number): string'
-				},
-				{
-					label: 'foo',
-					kind: CompletionItemKind.Method,
-					documentation: 'foo doc',
-					sortText: '0',
-					insertTextFormat: InsertTextFormat.Snippet,
-					insertText: 'foo()',
-					detail: '(method) A.foo(): void'
-				},
-				{
-					label: 'qux',
-					kind: CompletionItemKind.Property,
-					documentation: 'qux doc',
-					sortText: '0',
-					insertTextFormat: InsertTextFormat.Snippet,
-					insertText: 'qux',
-					detail: '(property) A.qux: number'
-				}
-			]);
+
+			const barItem = result.items.find(i => i.label === "bar") as CompletionItem;
+			const resolved: CompletionItem = await this.service.completionItemResolve(barItem)
+											   .reduce<Operation, CompletionItem>(applyReducer, null as any).toPromise();
+
+			assert.deepEqual(resolved, {
+				label: 'bar',
+				kind: CompletionItemKind.Method,
+				documentation: 'bar doc',
+				insertText: 'bar(${1:num})',
+				insertTextFormat: InsertTextFormat.Snippet,
+				sortText: '0',
+				detail: '(method) A.bar(num: number): number'
+			});
+
 		});
 	});
 
@@ -2259,42 +2236,76 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 			assert.equal(result.isIncomplete, false);
 			assert.sameDeepMembers(result.items, [
 				{
+					data: {
+						entryName: 'bar',
+						offset: 188,
+						uri: rootUri + 'a.ts'
+					},
 					label: 'bar',
 					kind: CompletionItemKind.Method,
-					documentation: 'bar doc',
-					insertText: 'bar',
-					insertTextFormat: InsertTextFormat.PlainText,
-					sortText: '0',
-					detail: '(method) A.bar(): number'
+					// documentation: 'bar doc',
+					// insertText: 'bar',
+					// insertTextFormat: InsertTextFormat.PlainText,
+					sortText: '0'
+					// detail: '(method) A.bar(): number'
 				},
 				{
+					data: {
+						entryName: 'baz',
+						offset: 188,
+						uri: rootUri + 'a.ts'
+					},
 					label: 'baz',
 					kind: CompletionItemKind.Method,
-					documentation: 'baz doc',
-					insertText: 'baz',
-					insertTextFormat: InsertTextFormat.PlainText,
-					sortText: '0',
-					detail: '(method) A.baz(): string'
+					// documentation: 'baz doc',
+					// insertText: 'baz',
+					// insertTextFormat: InsertTextFormat.PlainText,
+					sortText: '0'
+					// detail: '(method) A.baz(): string'
 				},
 				{
+					data: {
+						entryName: 'foo',
+						offset: 188,
+						uri: rootUri + 'a.ts'
+					},
 					label: 'foo',
 					kind: CompletionItemKind.Method,
-					documentation: 'foo doc',
-					insertText: 'foo',
-					insertTextFormat: InsertTextFormat.PlainText,
-					sortText: '0',
-					detail: '(method) A.foo(): void'
+					// documentation: 'foo doc',
+					// insertText: 'foo',
+					// insertTextFormat: InsertTextFormat.PlainText,
+					sortText: '0'
+					// detail: '(method) A.foo(): void'
 				},
 				{
+					data: {
+						entryName: 'qux',
+						offset: 188,
+						uri: rootUri + 'a.ts'
+					},
 					label: 'qux',
 					kind: CompletionItemKind.Property,
-					documentation: 'qux doc',
-					insertText: 'qux',
-					insertTextFormat: InsertTextFormat.PlainText,
-					sortText: '0',
-					detail: '(property) A.qux: number'
+					// documentation: 'qux doc',
+					// insertText: 'qux',
+					// insertTextFormat: InsertTextFormat.PlainText,
+					sortText: '0'
+					// detail: '(property) A.qux: number'
 				}
 			]);
+
+			const barItem = result.items.find(i => i.label === "bar") as CompletionItem;
+			const resolved: CompletionItem = await this.service.completionItemResolve(barItem)
+											   .reduce<Operation, CompletionItem>(applyReducer, null as any).toPromise();
+
+			assert.deepEqual(resolved, {
+				label: 'bar',
+				kind: CompletionItemKind.Method,
+				documentation: 'bar doc',
+				insertText: 'bar',
+				insertTextFormat: InsertTextFormat.PlainText,
+				sortText: '0',
+				detail: '(method) A.bar(): number'
+			});
 		});
 
 		it('produces completions for imported symbols', async function (this: TestContext & ITestCallbackContext) {
@@ -2310,12 +2321,17 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 			assert.deepEqual(result, {
 				isIncomplete: false,
 				items: [{
+					data: {
+						entryName: 'd',
+						offset: 32,
+						uri: rootUri + "uses-import.ts"
+					},
 					label: 'd',
 					kind: CompletionItemKind.Function,
-					documentation: 'd doc',
-					insertText: 'd',
-					insertTextFormat: InsertTextFormat.PlainText,
-					detail: 'function d(): void',
+					// documentation: 'd doc',
+					// insertText: 'd',
+					// insertTextFormat: InsertTextFormat.PlainText,
+					// detail: 'function d(): void',
 					sortText: '0'
 				}]
 			});
@@ -2333,13 +2349,18 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 			assert.deepEqual(result, {
 				isIncomplete: false,
 				items: [{
+					data: {
+						entryName: 'bar',
+						offset: 51,
+						uri: rootUri + "uses-reference.ts"
+					},
 					label: 'bar',
 					kind: CompletionItemKind.Interface,
-					documentation: 'bar doc',
-					insertText: 'bar',
-					insertTextFormat: InsertTextFormat.PlainText,
+					// documentation: 'bar doc',
+					// insertText: 'bar',
+					// insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0',
-					detail: 'interface foo.bar'
+					// detail: 'interface foo.bar'
 				}]
 			});
 		});

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2225,11 +2225,13 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 			//  * that is typing in one will update others too.
 			assert.equal(result.isIncomplete, false);
 
-			const resolveItem = (item: CompletionItem) => this.service
+			const resolvedItems = await Observable.from(result.items)
+				.mergeMap(item => this.service
 					.completionItemResolve(item)
-					.reduce<Operation, CompletionItem>(applyReducer, null as any).toPromise();
-
-			const resolvedItems = await Promise.all(result.items.map(resolveItem));
+					.reduce<Operation, CompletionItem>(applyReducer, null as any)
+				)
+				.toArray()
+				.toPromise();
 
 			assert.sameDeepMembers(resolvedItems, [
 				{

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -5,7 +5,7 @@ import { applyReducer, Operation } from 'fast-json-patch';
 import { IBeforeAndAfterContext, ISuiteCallbackContext, ITestCallbackContext } from 'mocha';
 import * as sinon from 'sinon';
 import * as ts from 'typescript';
-import { CompletionItemKind, CompletionList, DiagnosticSeverity, InsertTextFormat, TextDocumentIdentifier, TextDocumentItem, WorkspaceEdit, CompletionItem } from 'vscode-languageserver';
+import { CompletionItem, CompletionItemKind, CompletionList, DiagnosticSeverity, InsertTextFormat, TextDocumentIdentifier, TextDocumentItem, WorkspaceEdit } from 'vscode-languageserver';
 import { Command, Diagnostic, Hover, Location, SignatureHelp, SymbolInformation, SymbolKind } from 'vscode-languageserver-types';
 import { LanguageClient, RemoteLanguageClient } from '../lang-handler';
 import { DependencyReference, PackageInformation, ReferenceInformation, TextDocumentContentParams, WorkspaceFilesParams } from '../request-type';
@@ -2170,9 +2170,10 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 			//  * that is typing in one will update others too.
 			assert.equal(result.isIncomplete, false);
 
-			const barItem = result.items.find(i => i.label === "bar") as CompletionItem;
-			const resolved: CompletionItem = await this.service.completionItemResolve(barItem)
-											   .reduce<Operation, CompletionItem>(applyReducer, null as any).toPromise();
+			const barItem = result.items.find(i => i.label === 'bar') as CompletionItem;
+			const resolved: CompletionItem = await this.service
+				.completionItemResolve(barItem)
+				.reduce<Operation, CompletionItem>(applyReducer, null as any).toPromise();
 
 			assert.deepEqual(resolved, {
 				label: 'bar',
@@ -2293,9 +2294,10 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 				}
 			]);
 
-			const barItem = result.items.find(i => i.label === "bar") as CompletionItem;
-			const resolved: CompletionItem = await this.service.completionItemResolve(barItem)
-											   .reduce<Operation, CompletionItem>(applyReducer, null as any).toPromise();
+			const barItem = result.items.find(i => i.label === 'bar') as CompletionItem;
+			const resolved: CompletionItem = await this.service
+				.completionItemResolve(barItem)
+				.reduce<Operation, CompletionItem>(applyReducer, null as any).toPromise();
 
 			assert.deepEqual(resolved, {
 				label: 'bar',
@@ -2324,7 +2326,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					data: {
 						entryName: 'd',
 						offset: 32,
-						uri: rootUri + "uses-import.ts"
+						uri: rootUri + 'uses-import.ts'
 					},
 					label: 'd',
 					kind: CompletionItemKind.Function,
@@ -2352,14 +2354,14 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					data: {
 						entryName: 'bar',
 						offset: 51,
-						uri: rootUri + "uses-reference.ts"
+						uri: rootUri + 'uses-reference.ts'
 					},
 					label: 'bar',
 					kind: CompletionItemKind.Interface,
 					// documentation: 'bar doc',
 					// insertText: 'bar',
 					// insertTextFormat: InsertTextFormat.PlainText,
-					sortText: '0',
+					sortText: '0'
 					// detail: 'interface foo.bar'
 				}]
 			});

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2164,10 +2164,6 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					character: 2
 				}
 			}).reduce<Operation, CompletionList>(applyReducer, null as any).toPromise();
-			// * A snippet can define tab stops and placeholders with `$1`, `$2`
-			//  * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
-			//  * the end of the snippet. Placeholders with equal identifiers are linked,
-			//  * that is typing in one will update others too.
 			assert.equal(result.isIncomplete, false);
 			assert.sameDeepMembers(result.items, [
 				{
@@ -2337,11 +2333,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					label: 'bar',
 					kind: CompletionItemKind.Method,
-					// documentation: 'bar doc',
-					// insertText: 'bar',
-					// insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0'
-					// detail: '(method) A.bar(): number'
 				},
 				{
 					data: {
@@ -2351,11 +2343,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					label: 'baz',
 					kind: CompletionItemKind.Method,
-					// documentation: 'baz doc',
-					// insertText: 'baz',
-					// insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0'
-					// detail: '(method) A.baz(): string'
 				},
 				{
 					data: {
@@ -2365,11 +2353,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					label: 'foo',
 					kind: CompletionItemKind.Method,
-					// documentation: 'foo doc',
-					// insertText: 'foo',
-					// insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0'
-					// detail: '(method) A.foo(): void'
 				},
 				{
 					data: {
@@ -2379,11 +2363,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					label: 'qux',
 					kind: CompletionItemKind.Property,
-					// documentation: 'qux doc',
-					// insertText: 'qux',
-					// insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0'
-					// detail: '(property) A.qux: number'
 				}
 			]);
 		});
@@ -2471,10 +2451,6 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					label: 'd',
 					kind: CompletionItemKind.Function,
-					// documentation: 'd doc',
-					// insertText: 'd',
-					// insertTextFormat: InsertTextFormat.PlainText,
-					// detail: 'function d(): void',
 					sortText: '0'
 				}]
 			});
@@ -2499,11 +2475,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 					},
 					label: 'bar',
 					kind: CompletionItemKind.Interface,
-					// documentation: 'bar doc',
-					// insertText: 'bar',
-					// insertTextFormat: InsertTextFormat.PlainText,
 					sortText: '0'
-					// detail: 'interface foo.bar'
 				}]
 			});
 		});

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1025,8 +1025,8 @@ export class TypeScriptService {
 
 						// context for future resolve requests:
 						item.data = {
-							uri: uri,
-							offset: offset,
+							uri,
+							offset,
 							entryName: entry.name
 						};
 

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1044,7 +1044,7 @@ export class TypeScriptService {
 	 * @return Observable of JSON Patches that build a `CompletionItem` result
 	 */
 	completionItemResolve(item: CompletionItem, span = new Span()): Observable<Operation> {
-		if (item.data == null) {
+		if (!item.data) {
 			throw new Error('Cannot resolve completion item without data');
 		}
 		const {uri, offset, entryName} = item.data;

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -10,7 +10,6 @@ import * as url from 'url';
 import {
 	CodeActionParams,
 	Command,
-	CompletionItem,
 	CompletionItemKind,
 	CompletionList,
 	DidChangeConfigurationParams,
@@ -44,6 +43,7 @@ import { InMemoryFileSystem, isTypeScriptLibrary } from './memfs';
 import { extractDefinitelyTypedPackageName, extractNodeModulesPackageName, PackageJson, PackageManager } from './packages';
 import { ProjectConfiguration, ProjectManager } from './project-manager';
 import {
+	CompletionItem,
 	DependencyReference,
 	InitializeParams,
 	InitializeResult,
@@ -1044,6 +1044,9 @@ export class TypeScriptService {
 	 * @return Observable of JSON Patches that build a `CompletionItem` result
 	 */
 	completionItemResolve(item: CompletionItem, span = new Span()): Observable<Operation> {
+		if (item.data == null) {
+			throw new Error('Cannot resolve completion item without data');
+		}
 		const {uri, offset, entryName} = item.data;
 		const fileName: string = uri2path(uri);
 		return this.projectManager.ensureReferencedFiles(uri, undefined, undefined, span)
@@ -1073,7 +1076,7 @@ export class TypeScriptService {
 						item.insertTextFormat = InsertTextFormat.PlainText;
 						item.insertText = details.name;
 					}
-					delete item.data;
+					item.data = undefined;
 				}
 				return item;
 			})


### PR DESCRIPTION
Requesting extra completion details was found to be very expensive in #331, this PR will require clients to request these details via a separate request.

To do:
- [x] Clean up commented code