### PR TITLE
Delay diagnostics to give priority to other client requests

### DIFF
--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -1503,7 +1503,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 		});
 	});
 
-	describe('Diagnostics', function (this: TestContext & ISuiteCallbackContext) {
+	describe.only('Diagnostics', function (this: TestContext & ISuiteCallbackContext) {
 
 		beforeEach(initializeTypeScriptService(createService, rootUri, new Map([
 			[rootUri + 'src/errors.ts', 'const text: string = 33;']
@@ -1511,16 +1511,23 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 
 		afterEach(shutdownService);
 
+		function sleep(ms: number) {
+			return new Promise(resolve => setTimeout(resolve, ms));
+		}
+
 		it('should publish diagnostics on didOpen', async function (this: TestContext & ITestCallbackContext) {
 
-			await this.service.textDocumentDidOpen({
-				textDocument: {
-					uri: rootUri + 'src/errors.ts',
-					languageId: 'typescript',
-					text: 'const text: string = 33;',
-					version: 1
-				}
-			});
+			await Promise.all([
+				this.service.textDocumentDidOpen({
+					textDocument: {
+						uri: rootUri + 'src/errors.ts',
+						languageId: 'typescript',
+						text: 'const text: string = 33;',
+						version: 1
+					}
+				}),
+				sleep(300)
+			]);
 
 			sinon.assert.calledOnce(this.client.textDocumentPublishDiagnostics);
 			sinon.assert.calledWithExactly(this.client.textDocumentPublishDiagnostics, {
@@ -1537,26 +1544,32 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 
 		it('should publish diagnostics on didChange', async function (this: TestContext & ITestCallbackContext) {
 
-			await this.service.textDocumentDidOpen({
-				textDocument: {
-					uri: rootUri + 'src/errors.ts',
-					languageId: 'typescript',
-					text: 'const text: string = 33;',
-					version: 1
-				}
-			});
+			await Promise.all([
+				await this.service.textDocumentDidOpen({
+					textDocument: {
+						uri: rootUri + 'src/errors.ts',
+						languageId: 'typescript',
+						text: 'const text: string = 33;',
+						version: 1
+					}
+				}),
+				sleep(300)
+			]);
 
 			this.client.textDocumentPublishDiagnostics.resetHistory();
 
-			await this.service.textDocumentDidChange({
-				textDocument: {
-					uri: rootUri + 'src/errors.ts',
-					version: 2
-				},
-				contentChanges: [
-					{ text: 'const text: boolean = 33;' }
-				]
-			});
+			await Promise.all([
+				this.service.textDocumentDidChange({
+					textDocument: {
+						uri: rootUri + 'src/errors.ts',
+						version: 2
+					},
+					contentChanges: [
+						{ text: 'const text: boolean = 33;' }
+					]
+				}),
+				sleep(300)
+			]);
 
 			sinon.assert.calledOnce(this.client.textDocumentPublishDiagnostics);
 			sinon.assert.calledWithExactly(this.client.textDocumentPublishDiagnostics, {
@@ -1573,26 +1586,32 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 
 		it('should publish empty diagnostics on didChange if error was fixed', async function (this: TestContext & ITestCallbackContext) {
 
-			await this.service.textDocumentDidOpen({
-				textDocument: {
-					uri: rootUri + 'src/errors.ts',
-					languageId: 'typescript',
-					text: 'const text: string = 33;',
-					version: 1
-				}
-			});
+			await Promise.all([
+				this.service.textDocumentDidOpen({
+					textDocument: {
+						uri: rootUri + 'src/errors.ts',
+						languageId: 'typescript',
+						text: 'const text: string = 33;',
+						version: 1
+					}
+				}),
+				sleep(300)
+			]);
 
 			this.client.textDocumentPublishDiagnostics.resetHistory();
 
-			await this.service.textDocumentDidChange({
-				textDocument: {
-					uri: rootUri + 'src/errors.ts',
-					version: 2
-				},
-				contentChanges: [
-					{ text: 'const text: number = 33;' }
-				]
-			});
+			await Promise.all([
+				this.service.textDocumentDidChange({
+					textDocument: {
+						uri: rootUri + 'src/errors.ts',
+						version: 2
+					},
+					contentChanges: [
+						{ text: 'const text: number = 33;' }
+					]
+				}),
+				sleep(300)
+			]);
 
 			sinon.assert.calledOnce(this.client.textDocumentPublishDiagnostics);
 			sinon.assert.calledWithExactly(this.client.textDocumentPublishDiagnostics, {

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -1503,7 +1503,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 		});
 	});
 
-	describe.only('Diagnostics', function (this: TestContext & ISuiteCallbackContext) {
+	describe('Diagnostics', function (this: TestContext & ISuiteCallbackContext) {
 
 		beforeEach(initializeTypeScriptService(createService, rootUri, new Map([
 			[rootUri + 'src/errors.ts', 'const text: string = 33;']
@@ -1511,23 +1511,16 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 
 		afterEach(shutdownService);
 
-		function sleep(ms: number) {
-			return new Promise(resolve => setTimeout(resolve, ms));
-		}
-
 		it('should publish diagnostics on didOpen', async function (this: TestContext & ITestCallbackContext) {
 
-			await Promise.all([
-				this.service.textDocumentDidOpen({
-					textDocument: {
-						uri: rootUri + 'src/errors.ts',
-						languageId: 'typescript',
-						text: 'const text: string = 33;',
-						version: 1
-					}
-				}),
-				sleep(300)
-			]);
+			await this.service.textDocumentDidOpen({
+				textDocument: {
+					uri: rootUri + 'src/errors.ts',
+					languageId: 'typescript',
+					text: 'const text: string = 33;',
+					version: 1
+				}
+			});
 
 			sinon.assert.calledOnce(this.client.textDocumentPublishDiagnostics);
 			sinon.assert.calledWithExactly(this.client.textDocumentPublishDiagnostics, {
@@ -1544,32 +1537,26 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 
 		it('should publish diagnostics on didChange', async function (this: TestContext & ITestCallbackContext) {
 
-			await Promise.all([
-				await this.service.textDocumentDidOpen({
-					textDocument: {
-						uri: rootUri + 'src/errors.ts',
-						languageId: 'typescript',
-						text: 'const text: string = 33;',
-						version: 1
-					}
-				}),
-				sleep(300)
-			]);
+			await this.service.textDocumentDidOpen({
+				textDocument: {
+					uri: rootUri + 'src/errors.ts',
+					languageId: 'typescript',
+					text: 'const text: string = 33;',
+					version: 1
+				}
+			});
 
 			this.client.textDocumentPublishDiagnostics.resetHistory();
 
-			await Promise.all([
-				this.service.textDocumentDidChange({
-					textDocument: {
-						uri: rootUri + 'src/errors.ts',
-						version: 2
-					},
-					contentChanges: [
-						{ text: 'const text: boolean = 33;' }
-					]
-				}),
-				sleep(300)
-			]);
+			await this.service.textDocumentDidChange({
+				textDocument: {
+					uri: rootUri + 'src/errors.ts',
+					version: 2
+				},
+				contentChanges: [
+					{ text: 'const text: boolean = 33;' }
+				]
+			});
 
 			sinon.assert.calledOnce(this.client.textDocumentPublishDiagnostics);
 			sinon.assert.calledWithExactly(this.client.textDocumentPublishDiagnostics, {
@@ -1586,32 +1573,26 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
 
 		it('should publish empty diagnostics on didChange if error was fixed', async function (this: TestContext & ITestCallbackContext) {
 
-			await Promise.all([
-				this.service.textDocumentDidOpen({
-					textDocument: {
-						uri: rootUri + 'src/errors.ts',
-						languageId: 'typescript',
-						text: 'const text: string = 33;',
-						version: 1
-					}
-				}),
-				sleep(300)
-			]);
+			await this.service.textDocumentDidOpen({
+				textDocument: {
+					uri: rootUri + 'src/errors.ts',
+					languageId: 'typescript',
+					text: 'const text: string = 33;',
+					version: 1
+				}
+			});
 
 			this.client.textDocumentPublishDiagnostics.resetHistory();
 
-			await Promise.all([
-				this.service.textDocumentDidChange({
-					textDocument: {
-						uri: rootUri + 'src/errors.ts',
-						version: 2
-					},
-					contentChanges: [
-						{ text: 'const text: number = 33;' }
-					]
-				}),
-				sleep(300)
-			]);
+			await this.service.textDocumentDidChange({
+				textDocument: {
+					uri: rootUri + 'src/errors.ts',
+					version: 2
+				},
+				contentChanges: [
+					{ text: 'const text: number = 33;' }
+				]
+			});
 
 			sinon.assert.calledOnce(this.client.textDocumentPublishDiagnostics);
 			sinon.assert.calledWithExactly(this.client.textDocumentPublishDiagnostics, {

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1267,7 +1267,7 @@ export class TypeScriptService {
 		// Ensure files needed for most operations are fetched
 		await this.projectManager.ensureReferencedFiles(uri).toPromise();
 		this.projectManager.didOpen(uri, params.textDocument.text);
-		this._publishDiagnostics(uri);
+		setTimeout(() => this._publishDiagnostics(uri), 200);
 	}
 
 	/**
@@ -1288,7 +1288,7 @@ export class TypeScriptService {
 			return;
 		}
 		this.projectManager.didChange(uri, text);
-		this._publishDiagnostics(uri);
+		setTimeout(() => this._publishDiagnostics(uri), 200);
 	}
 
 	/**

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1267,7 +1267,8 @@ export class TypeScriptService {
 		// Ensure files needed for most operations are fetched
 		await this.projectManager.ensureReferencedFiles(uri).toPromise();
 		this.projectManager.didOpen(uri, params.textDocument.text);
-		setTimeout(() => this._publishDiagnostics(uri), 200);
+		await new Promise(resolve => setTimeout(resolve, 200));
+		this._publishDiagnostics(uri);
 	}
 
 	/**
@@ -1288,7 +1289,8 @@ export class TypeScriptService {
 			return;
 		}
 		this.projectManager.didChange(uri, text);
-		setTimeout(() => this._publishDiagnostics(uri), 200);
+		await new Promise(resolve => setTimeout(resolve, 200));
+		this._publishDiagnostics(uri);
 	}
 
 	/**


### PR DESCRIPTION
This should remove an initial delay before the language server answers a completion request (see #331)
Currently uses setTimeout, would like to know about a preferable approach?