### PR TITLE
Fix global type loading on Windows paths

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -24,6 +24,8 @@ import {
     uri2path
 } from './util'
 
+const LastForwardOrBackwardSlash = /[\\\/][^\\\/]*$/
+
 /**
  * Implementaton of LanguageServiceHost that works with in-memory file system.
  * It takes file content from local cache and provides it to TS compiler on demand
@@ -622,7 +624,7 @@ export class ProjectManager implements Disposable {
                 .filter(([uri, content]) => !!content && /\/[tj]sconfig\.json/.test(uri) && !uri.includes('/node_modules/'))
                 .subscribe(([uri, content]) => {
                     const filePath = uri2path(uri)
-                    const pos = filePath.includes('\\') ? filePath.lastIndexOf('\\') : filePath.lastIndexOf('/')
+                    const pos = filePath.search(LastForwardOrBackwardSlash)
                     const dir = pos <= 0 ? '' : filePath.substring(0, pos)
                     const configType = this.getConfigurationType(filePath)
                     const configs = this.configs[configType]
@@ -937,7 +939,7 @@ export class ProjectManager implements Disposable {
             if (config) {
                 return config
             }
-            const pos = dir.includes('\\') ? dir.lastIndexOf('\\') : dir.lastIndexOf('/')
+            const pos = dir.search(LastForwardOrBackwardSlash)
             if (pos <= 0) {
                 dir = ''
             } else {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -405,7 +405,7 @@ export class ProjectConfiguration {
      */
     public isExpectedDeclarationFile(fileName: string): boolean {
         return isDeclarationFile(fileName) &&
-                (this.expectedFilePaths.has(toUnixPath(fileName)) ||
+                (this.expectedFilePaths.has(fileName) ||
                 this.typeRoots.some(root => fileName.startsWith(root)))
     }
 
@@ -427,8 +427,9 @@ export class ProjectConfiguration {
         // Add all global declaration files from the workspace and all declarations from the project
         for (const uri of this.fs.uris()) {
             const fileName = uri2path(uri)
-            if (isGlobalTSFile(fileName) ||
-                this.isExpectedDeclarationFile(fileName)) {
+            const unixPath = toUnixPath(fileName)
+            if (isGlobalTSFile(unixPath) ||
+                this.isExpectedDeclarationFile(unixPath)) {
                 const sourceFile = program.getSourceFile(fileName)
                 if (!sourceFile) {
                     this.getHost().addFile(fileName)

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -343,7 +343,7 @@ export class ProjectConfiguration {
         const options = configParseResult.options
         const pathResolver = /^[a-z]:\//i.test(base) ? path.win32 : path.posix
         this.typeRoots = options.typeRoots ?
-            options.typeRoots.map((r: string) => pathResolver.resolve(this.rootFilePath, r)) :
+            options.typeRoots.map((r: string) => toUnixPath(pathResolver.resolve(this.rootFilePath, r))) :
             []
 
         if (/(^|\/)jsconfig\.json$/.test(this.configFilePath)) {
@@ -833,7 +833,7 @@ export class ProjectManager implements Disposable {
         return traceObservable('Ensure config dependencies', childOf, span => {
             if (!this.ensuredConfigDependencies) {
                 this.ensuredConfigDependencies = observableFromIterable(this.inMemoryFs.uris())
-                .filter(uri => this.isConfigDependency(uri2path(uri)))
+                .filter(uri => this.isConfigDependency(toUnixPath(uri2path(uri))))
                 .mergeMap(uri => this.updater.ensure(uri))
                 .do(noop, err => {
                     this.ensuredConfigDependencies = undefined

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -495,6 +495,8 @@ export type ConfigType = 'js' | 'ts'
  * makes one or more LanguageService objects. By default all LanguageService objects contain no files,
  * they are added on demand - current file for hover or definition, project's files for references and
  * all files from all projects for workspace symbols.
+ *
+ * ProjectManager preserves Windows paths until passed to ProjectConfiguration or TS APIs.
  */
 export class ProjectManager implements Disposable {
 

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -24,7 +24,7 @@ import {
     uri2path
 } from './util'
 
-const LastForwardOrBackwardSlash = /[\\\/][^\\\/]*$/
+const LAST_FORWARD_OR_BACKWARD_SLASH = /[\\\/][^\\\/]*$/
 
 /**
  * Implementaton of LanguageServiceHost that works with in-memory file system.
@@ -631,7 +631,7 @@ export class ProjectManager implements Disposable {
                 .filter(([uri, content]) => !!content && /\/[tj]sconfig\.json/.test(uri) && !uri.includes('/node_modules/'))
                 .subscribe(([uri, content]) => {
                     const filePath = uri2path(uri)
-                    const pos = filePath.search(LastForwardOrBackwardSlash)
+                    const pos = filePath.search(LAST_FORWARD_OR_BACKWARD_SLASH)
                     const dir = pos <= 0 ? '' : filePath.substring(0, pos)
                     const configType = this.getConfigurationType(filePath)
                     const configs = this.configs[configType]
@@ -946,7 +946,7 @@ export class ProjectManager implements Disposable {
             if (config) {
                 return config
             }
-            const pos = dir.search(LastForwardOrBackwardSlash)
+            const pos = dir.search(LAST_FORWARD_OR_BACKWARD_SLASH)
             if (pos <= 0) {
                 dir = ''
             } else {

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -185,6 +185,10 @@ export class InMemoryLanguageServiceHost implements ts.LanguageServiceHost {
  * made available to the compiler before calling any other methods on
  * the ProjectConfiguration or its public members. By default, no
  * files are parsed.
+ *
+ * Windows file paths are converted to UNIX-style forward slashes
+ * when compared with Typescript configuration (isGlobalTSFile,
+ * expectedFilePaths and typeRoots)
  */
 export class ProjectConfiguration {
 
@@ -227,12 +231,13 @@ export class ProjectConfiguration {
 
     /**
      * List of files that project consist of (based on tsconfig includes/excludes and wildcards).
-     * Each item is a relative file path
+     * Each item is a relative UNIX-like file path
      */
     private expectedFilePaths = new Set<string>()
 
     /**
      * List of resolved extra root directories to allow global type declaration files to be loaded from.
+     * Each item is an absolute UNIX-like file path
      */
     private typeRoots: string[]
 
@@ -403,7 +408,7 @@ export class ProjectConfiguration {
 
     /**
      * Determines if a fileName is a declaration file within expected files or type roots
-     * @param fileName
+     * @param fileName A Unix-like absolute file path.
      */
     public isExpectedDeclarationFile(fileName: string): boolean {
         return isDeclarationFile(fileName) &&
@@ -811,7 +816,7 @@ export class ProjectManager implements Disposable {
 
     /**
      * Determines if a tsconfig/jsconfig needs additional declaration files loaded.
-     * @param filePath
+     * @param filePath A UNIX-like absolute file path
      */
     public isConfigDependency(filePath: string): boolean {
         for (const config of this.configurations()) {

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -10,170 +10,166 @@ const assert = chai.assert
 
 describe('ProjectManager', () => {
     for (const rootUri of ['file:///', 'file:///c:/foo/bar/', 'file:///foo/bar/']) {
-        testWithRootUri(rootUri)
+        describe(`with rootUri ${rootUri}`, () => {
+
+            let projectManager: ProjectManager
+            let memfs: InMemoryFileSystem
+
+            it('should add a ProjectConfiguration when a tsconfig.json is added to the InMemoryFileSystem', () => {
+                const rootPath = uri2path(rootUri)
+                memfs = new InMemoryFileSystem(rootPath)
+                const configFileUri = rootUri + 'foo/tsconfig.json'
+                const localfs = new MapFileSystem(new Map([
+                    [configFileUri, '{}']
+                ]))
+                const updater = new FileSystemUpdater(localfs, memfs)
+                projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                memfs.add(configFileUri, '{}')
+                const configs = Array.from(projectManager.configurations())
+                const expectedConfigFilePath = uri2path(configFileUri)
+
+                assert.isDefined(configs.find(config => config.configFilePath === expectedConfigFilePath))
+            })
+
+            describe('ensureBasicFiles', () => {
+                beforeEach(async () => {
+                    const rootPath = uri2path(rootUri)
+                    memfs = new InMemoryFileSystem(rootPath)
+                    const localfs = new MapFileSystem(new Map([
+                        [rootUri + 'project/package.json', '{"name": "package-name-1"}'],
+                        [rootUri + 'project/tsconfig.json', '{ "compilerOptions": { "typeRoots": ["../types"]} }'],
+                        [rootUri + 'project/node_modules/%40types/mocha/index.d.ts', 'declare var describe { (description: string, spec: () => void): void; }'],
+                        [rootUri + 'project/file.ts', 'describe("test", () => console.log(GLOBALCONSTANT));'],
+                        [rootUri + 'types/types.d.ts', 'declare var GLOBALCONSTANT=1;']
+
+                    ]))
+                    const updater = new FileSystemUpdater(localfs, memfs)
+                    projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                })
+
+                it('loads files from typeRoots', async () => {
+                    const sourceFileUri = rootUri + 'project/file.ts'
+                    const typeRootFileUri = rootUri + 'types/types.d.ts'
+                    await projectManager.ensureReferencedFiles(sourceFileUri).toPromise()
+                    memfs.getContent(typeRootFileUri)
+
+                    const config = projectManager.getConfiguration(uri2path(sourceFileUri), 'ts')
+                    const host = config.getHost()
+                    const typeDeclarationPath = uri2path(typeRootFileUri)
+                    assert.includeMembers(host.getScriptFileNames(), [typeDeclarationPath])
+                })
+
+                it('loads mocha global type declarations', async () => {
+                    const sourceFileUri = rootUri + 'project/file.ts'
+                    const mochaDeclarationFileUri = rootUri + 'project/node_modules/%40types/mocha/index.d.ts'
+                    await projectManager.ensureReferencedFiles(sourceFileUri).toPromise()
+                    memfs.getContent(mochaDeclarationFileUri)
+
+                    const config = projectManager.getConfiguration(uri2path(sourceFileUri), 'ts')
+                    const host = config.getHost()
+                    const mochaFilePath = uri2path(mochaDeclarationFileUri)
+                    assert.includeMembers(host.getScriptFileNames(), [mochaFilePath])
+                })
+            })
+
+            describe('getPackageName()', () => {
+                beforeEach(async () => {
+                    const rootPath = uri2path(rootUri)
+                    memfs = new InMemoryFileSystem(rootPath)
+                    const localfs = new MapFileSystem(new Map([
+                        [rootUri + 'package.json', '{"name": "package-name-1"}'],
+                        [rootUri + 'subdirectory-with-tsconfig/package.json', '{"name": "package-name-2"}'],
+                        [rootUri + 'subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
+                        [rootUri + 'subdirectory-with-tsconfig/src/dummy.ts', '']
+                    ]))
+                    const updater = new FileSystemUpdater(localfs, memfs)
+                    projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                    await projectManager.ensureAllFiles().toPromise()
+                })
+            })
+
+            describe('ensureReferencedFiles()', () => {
+                beforeEach(() => {
+                    const rootPath = uri2path(rootUri)
+                    memfs = new InMemoryFileSystem(rootPath)
+                    const localfs = new MapFileSystem(new Map([
+                        [rootUri + 'package.json', '{"name": "package-name-1"}'],
+                        [rootUri + 'node_modules/somelib/index.js', '/// <reference path="./pathref.d.ts"/>\n/// <reference types="node"/>'],
+                        [rootUri + 'node_modules/somelib/pathref.d.ts', ''],
+                        [rootUri + 'node_modules/%40types/node/index.d.ts', ''],
+                        [rootUri + 'src/dummy.ts', 'import * as somelib from "somelib";']
+                    ]))
+                    const updater = new FileSystemUpdater(localfs, memfs)
+                    projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                })
+                it('should ensure content for imports and references is fetched', async () => {
+                    await projectManager.ensureReferencedFiles(rootUri + 'src/dummy.ts').toPromise()
+                    memfs.getContent(rootUri + 'node_modules/somelib/index.js')
+                    memfs.getContent(rootUri + 'node_modules/somelib/pathref.d.ts')
+                    memfs.getContent(rootUri + 'node_modules/%40types/node/index.d.ts')
+                })
+            })
+            describe('getConfiguration()', () => {
+                beforeEach(async () => {
+                    const rootPath = uri2path(rootUri)
+                    memfs = new InMemoryFileSystem(rootPath)
+                    const localfs = new MapFileSystem(new Map([
+                        [rootUri + 'tsconfig.json', '{}'],
+                        [rootUri + 'src/jsconfig.json', '{}']
+                    ]))
+                    const updater = new FileSystemUpdater(localfs, memfs)
+                    projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                    await projectManager.ensureAllFiles().toPromise()
+                })
+                it('should resolve best configuration based on file name', () => {
+                    const jsConfig = projectManager.getConfiguration(uri2path(rootUri + 'src/foo.js'))
+                    const tsConfig = projectManager.getConfiguration(uri2path(rootUri + 'src/foo.ts'))
+                    assert.equal(uri2path(rootUri + 'tsconfig.json'), tsConfig.configFilePath)
+                    assert.equal(uri2path(rootUri + 'src/jsconfig.json'), jsConfig.configFilePath)
+                    assert.equal(Array.from(projectManager.configurations()).length, 2)
+                })
+            })
+            describe('getParentConfiguration()', () => {
+                beforeEach(async () => {
+                    const rootPath = uri2path(rootUri)
+                    memfs = new InMemoryFileSystem(rootPath)
+                    const localfs = new MapFileSystem(new Map([
+                        [rootUri + 'tsconfig.json', '{}'],
+                        [rootUri + 'src/jsconfig.json', '{}']
+                    ]))
+                    const updater = new FileSystemUpdater(localfs, memfs)
+                    projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                    await projectManager.ensureAllFiles().toPromise()
+                })
+                it('should resolve best configuration based on file name', () => {
+                    const config = projectManager.getParentConfiguration(rootUri + 'src/foo.ts')
+                    assert.isDefined(config)
+                    assert.equal(uri2path(rootUri + 'tsconfig.json'), config!.configFilePath)
+                    assert.equal(Array.from(projectManager.configurations()).length, 2)
+                })
+            })
+            describe('getChildConfigurations()', () => {
+                beforeEach(async () => {
+                    const rootPath = uri2path(rootUri)
+                    memfs = new InMemoryFileSystem(rootPath)
+                    const localfs = new MapFileSystem(new Map([
+                        [rootUri + 'tsconfig.json', '{}'],
+                        [rootUri + 'foo/bar/tsconfig.json', '{}'],
+                        [rootUri + 'foo/baz/tsconfig.json', '{}']
+                    ]))
+                    const updater = new FileSystemUpdater(localfs, memfs)
+                    projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                    await projectManager.ensureAllFiles().toPromise()
+                })
+                it('should resolve best configuration based on file name', () => {
+                    const configs = Array.from(projectManager.getChildConfigurations(rootUri + 'foo')).map(config => config.configFilePath)
+                    assert.deepEqual(configs, [
+                        uri2path(rootUri + 'foo/bar/tsconfig.json'),
+                        uri2path(rootUri + 'foo/baz/tsconfig.json')
+                    ])
+                    assert.equal(Array.from(projectManager.configurations()).length, 4)
+                })
+            })
+        })
     }
 })
-
-function testWithRootUri(rootUri: string): void {
-    describe(`with rootUri ${rootUri}`, () => {
-
-        let projectManager: ProjectManager
-        let memfs: InMemoryFileSystem
-
-        it('should add a ProjectConfiguration when a tsconfig.json is added to the InMemoryFileSystem', () => {
-            const rootPath = uri2path(rootUri)
-            memfs = new InMemoryFileSystem(rootPath)
-            const configFileUri = rootUri + 'foo/tsconfig.json'
-            const localfs = new MapFileSystem(new Map([
-                [configFileUri, '{}']
-            ]))
-            const updater = new FileSystemUpdater(localfs, memfs)
-            projectManager = new ProjectManager(rootPath, memfs, updater, true)
-            memfs.add(configFileUri, '{}')
-            const configs = Array.from(projectManager.configurations())
-            const expectedConfigFilePath = uri2path(configFileUri)
-
-            assert.isDefined(configs.find(config => config.configFilePath === expectedConfigFilePath))
-        })
-
-        describe('ensureBasicFiles', () => {
-            beforeEach(async () => {
-                const rootPath = uri2path(rootUri)
-                memfs = new InMemoryFileSystem(rootPath)
-                const localfs = new MapFileSystem(new Map([
-                    [rootUri + 'project/package.json', '{"name": "package-name-1"}'],
-                    [rootUri + 'project/tsconfig.json', '{ "compilerOptions": { "typeRoots": ["../types"]} }'],
-                    [rootUri + 'project/node_modules/%40types/mocha/index.d.ts', 'declare var describe { (description: string, spec: () => void): void; }'],
-                    [rootUri + 'project/file.ts', 'describe("test", () => console.log(GLOBALCONSTANT));'],
-                    [rootUri + 'types/types.d.ts', 'declare var GLOBALCONSTANT=1;']
-
-                ]))
-                const updater = new FileSystemUpdater(localfs, memfs)
-                projectManager = new ProjectManager(rootPath, memfs, updater, true)
-            })
-
-            it('loads files from typeRoots', async () => {
-                const sourceFileUri = rootUri + 'project/file.ts'
-                const typeRootFileUri = rootUri + 'types/types.d.ts'
-                await projectManager.ensureReferencedFiles(sourceFileUri).toPromise()
-                memfs.getContent(typeRootFileUri)
-
-                const config = projectManager.getConfiguration(uri2path(sourceFileUri), 'ts')
-                const host = config.getHost()
-                const typeDeclarationPath = uri2path(typeRootFileUri)
-                assert.includeMembers(host.getScriptFileNames(), [typeDeclarationPath])
-            })
-
-            it('loads mocha global type declarations', async () => {
-                const sourceFileUri = rootUri + 'project/file.ts'
-                const mochaDeclarationFileUri = rootUri + 'project/node_modules/%40types/mocha/index.d.ts'
-                await projectManager.ensureReferencedFiles(sourceFileUri).toPromise()
-                memfs.getContent(mochaDeclarationFileUri)
-
-                const config = projectManager.getConfiguration(uri2path(sourceFileUri), 'ts')
-                const host = config.getHost()
-                const mochaFilePath = uri2path(mochaDeclarationFileUri)
-                assert.includeMembers(host.getScriptFileNames(), [mochaFilePath])
-            })
-        })
-
-        describe('getPackageName()', () => {
-            beforeEach(async () => {
-                const rootPath = uri2path(rootUri)
-                memfs = new InMemoryFileSystem(rootPath)
-                const localfs = new MapFileSystem(new Map([
-                    [rootUri + 'package.json', '{"name": "package-name-1"}'],
-                    [rootUri + 'subdirectory-with-tsconfig/package.json', '{"name": "package-name-2"}'],
-                    [rootUri + 'subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
-                    [rootUri + 'subdirectory-with-tsconfig/src/dummy.ts', '']
-                ]))
-                const updater = new FileSystemUpdater(localfs, memfs)
-                projectManager = new ProjectManager(rootPath, memfs, updater, true)
-                await projectManager.ensureAllFiles().toPromise()
-            })
-        })
-
-        describe('ensureReferencedFiles()', () => {
-            beforeEach(() => {
-                const rootPath = uri2path(rootUri)
-                memfs = new InMemoryFileSystem(rootPath)
-                const localfs = new MapFileSystem(new Map([
-                    [rootUri + 'package.json', '{"name": "package-name-1"}'],
-                    [rootUri + 'node_modules/somelib/index.js', '/// <reference path="./pathref.d.ts"/>\n/// <reference types="node"/>'],
-                    [rootUri + 'node_modules/somelib/pathref.d.ts', ''],
-                    [rootUri + 'node_modules/%40types/node/index.d.ts', ''],
-                    [rootUri + 'src/dummy.ts', 'import * as somelib from "somelib";']
-                ]))
-                const updater = new FileSystemUpdater(localfs, memfs)
-                projectManager = new ProjectManager(rootPath, memfs, updater, true)
-            })
-            it('should ensure content for imports and references is fetched', async () => {
-                await projectManager.ensureReferencedFiles(rootUri + 'src/dummy.ts').toPromise()
-                memfs.getContent(rootUri + 'node_modules/somelib/index.js')
-                memfs.getContent(rootUri + 'node_modules/somelib/pathref.d.ts')
-                memfs.getContent(rootUri + 'node_modules/%40types/node/index.d.ts')
-            })
-        })
-        describe('getConfiguration()', () => {
-            beforeEach(async () => {
-                const rootPath = uri2path(rootUri)
-                memfs = new InMemoryFileSystem(rootPath)
-                const localfs = new MapFileSystem(new Map([
-                    [rootUri + 'tsconfig.json', '{}'],
-                    [rootUri + 'src/jsconfig.json', '{}']
-                ]))
-                const updater = new FileSystemUpdater(localfs, memfs)
-                projectManager = new ProjectManager(rootPath, memfs, updater, true)
-                await projectManager.ensureAllFiles().toPromise()
-            })
-            it('should resolve best configuration based on file name', () => {
-                const jsConfig = projectManager.getConfiguration(uri2path(rootUri + 'src/foo.js'))
-                const tsConfig = projectManager.getConfiguration(uri2path(rootUri + 'src/foo.ts'))
-                assert.equal(uri2path(rootUri + 'tsconfig.json'), tsConfig.configFilePath)
-                assert.equal(uri2path(rootUri + 'src/jsconfig.json'), jsConfig.configFilePath)
-                assert.equal(Array.from(projectManager.configurations()).length, 2)
-            })
-        })
-        describe('getParentConfiguration()', () => {
-            beforeEach(async () => {
-                const rootPath = uri2path(rootUri)
-                memfs = new InMemoryFileSystem(rootPath)
-                const localfs = new MapFileSystem(new Map([
-                    [rootUri + 'tsconfig.json', '{}'],
-                    [rootUri + 'src/jsconfig.json', '{}']
-                ]))
-                const updater = new FileSystemUpdater(localfs, memfs)
-                projectManager = new ProjectManager(rootPath, memfs, updater, true)
-                await projectManager.ensureAllFiles().toPromise()
-            })
-            it('should resolve best configuration based on file name', () => {
-                const config = projectManager.getParentConfiguration(rootUri + 'src/foo.ts')
-                assert.isDefined(config)
-                assert.equal(uri2path(rootUri + 'tsconfig.json'), config!.configFilePath)
-                assert.equal(Array.from(projectManager.configurations()).length, 2)
-            })
-        })
-        describe('getChildConfigurations()', () => {
-            beforeEach(async () => {
-                const rootPath = uri2path(rootUri)
-                memfs = new InMemoryFileSystem(rootPath)
-                const localfs = new MapFileSystem(new Map([
-                    [rootUri + 'tsconfig.json', '{}'],
-                    [rootUri + 'foo/bar/tsconfig.json', '{}'],
-                    [rootUri + 'foo/baz/tsconfig.json', '{}']
-                ]))
-                const updater = new FileSystemUpdater(localfs, memfs)
-                projectManager = new ProjectManager(rootPath, memfs, updater, true)
-                await projectManager.ensureAllFiles().toPromise()
-            })
-            it('should resolve best configuration based on file name', () => {
-                const configs = Array.from(projectManager.getChildConfigurations(rootUri + 'foo')).map(config => config.configFilePath)
-                assert.deepEqual(configs, [
-                    uri2path(rootUri + 'foo/bar/tsconfig.json'),
-                    uri2path(rootUri + 'foo/baz/tsconfig.json')
-                ])
-                assert.equal(Array.from(projectManager.configurations()).length, 4)
-            })
-        })
-    })
-}

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -3,134 +3,157 @@ import chaiAsPromised = require('chai-as-promised')
 import { FileSystemUpdater } from '../fs'
 import { InMemoryFileSystem } from '../memfs'
 import { ProjectManager } from '../project-manager'
+import { uri2path } from '../util'
 import { MapFileSystem } from './fs-helpers'
 chai.use(chaiAsPromised)
 const assert = chai.assert
 
 describe('ProjectManager', () => {
-
-    let projectManager: ProjectManager
-    let memfs: InMemoryFileSystem
-
-    it('should add a ProjectConfiguration when a tsconfig.json is added to the InMemoryFileSystem', () => {
-        memfs = new InMemoryFileSystem('/')
-        const localfs = new MapFileSystem(new Map([
-            ['file:///foo/tsconfig.json', '{}']
-        ]))
-        const updater = new FileSystemUpdater(localfs, memfs)
-        projectManager = new ProjectManager('/', memfs, updater, true)
-        memfs.add('file:///foo/tsconfig.json', '{}')
-        const configs = Array.from(projectManager.configurations())
-        assert.isDefined(configs.find(config => config.configFilePath === '/foo/tsconfig.json'))
-    })
-
-    describe('ensureBasicFiles', () => {
-        beforeEach(async () => {
-            memfs = new InMemoryFileSystem('/')
-            const localfs = new MapFileSystem(new Map([
-                ['file:///project/package.json', '{"name": "package-name-1"}'],
-                ['file:///project/tsconfig.json', '{ "compilerOptions": { "typeRoots": ["../types"]} }'],
-                ['file:///project/file.ts', 'console.log(GLOBALCONSTANT);'],
-                ['file:///types/types.d.ts', 'declare var GLOBALCONSTANT=1;']
-
-            ]))
-            const updater = new FileSystemUpdater(localfs, memfs)
-            projectManager = new ProjectManager('/', memfs, updater, true)
-        })
-        it('loads files from typeRoots', async () => {
-            await projectManager.ensureReferencedFiles('file:///project/file.ts').toPromise()
-            memfs.getContent('file:///project/file.ts')
-            memfs.getContent('file:///types/types.d.ts')
-        })
-    })
-
-    describe('getPackageName()', () => {
-        beforeEach(async () => {
-            memfs = new InMemoryFileSystem('/')
-            const localfs = new MapFileSystem(new Map([
-                ['file:///package.json', '{"name": "package-name-1"}'],
-                ['file:///subdirectory-with-tsconfig/package.json', '{"name": "package-name-2"}'],
-                ['file:///subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
-                ['file:///subdirectory-with-tsconfig/src/dummy.ts', '']
-            ]))
-            const updater = new FileSystemUpdater(localfs, memfs)
-            projectManager = new ProjectManager('/', memfs, updater, true)
-            await projectManager.ensureAllFiles().toPromise()
-        })
-    })
-    describe('ensureReferencedFiles()', () => {
-        beforeEach(() => {
-            memfs = new InMemoryFileSystem('/')
-            const localfs = new MapFileSystem(new Map([
-                ['file:///package.json', '{"name": "package-name-1"}'],
-                ['file:///node_modules/somelib/index.js', '/// <reference path="./pathref.d.ts"/>\n/// <reference types="node"/>'],
-                ['file:///node_modules/somelib/pathref.d.ts', ''],
-                ['file:///node_modules/%40types/node/index.d.ts', ''],
-                ['file:///src/dummy.ts', 'import * as somelib from "somelib";']
-            ]))
-            const updater = new FileSystemUpdater(localfs, memfs)
-            projectManager = new ProjectManager('/', memfs, updater, true)
-        })
-        it('should ensure content for imports and references is fetched', async () => {
-            await projectManager.ensureReferencedFiles('file:///src/dummy.ts').toPromise()
-            memfs.getContent('file:///node_modules/somelib/index.js')
-            memfs.getContent('file:///node_modules/somelib/pathref.d.ts')
-            memfs.getContent('file:///node_modules/%40types/node/index.d.ts')
-        })
-    })
-    describe('getConfiguration()', () => {
-        beforeEach(async () => {
-            memfs = new InMemoryFileSystem('/')
-            const localfs = new MapFileSystem(new Map([
-                ['file:///tsconfig.json', '{}'],
-                ['file:///src/jsconfig.json', '{}']
-            ]))
-            const updater = new FileSystemUpdater(localfs, memfs)
-            projectManager = new ProjectManager('/', memfs, updater, true)
-            await projectManager.ensureAllFiles().toPromise()
-        })
-        it('should resolve best configuration based on file name', () => {
-            const jsConfig = projectManager.getConfiguration('/src/foo.js')
-            const tsConfig = projectManager.getConfiguration('/src/foo.ts')
-            assert.equal('/tsconfig.json', tsConfig.configFilePath)
-            assert.equal('/src/jsconfig.json', jsConfig.configFilePath)
-        })
-    })
-    describe('getParentConfiguration()', () => {
-        beforeEach(async () => {
-            memfs = new InMemoryFileSystem('/')
-            const localfs = new MapFileSystem(new Map([
-                ['file:///tsconfig.json', '{}'],
-                ['file:///src/jsconfig.json', '{}']
-            ]))
-            const updater = new FileSystemUpdater(localfs, memfs)
-            projectManager = new ProjectManager('/', memfs, updater, true)
-            await projectManager.ensureAllFiles().toPromise()
-        })
-        it('should resolve best configuration based on file name', () => {
-            const config = projectManager.getParentConfiguration('file:///src/foo.ts')
-            assert.isDefined(config)
-            assert.equal('/tsconfig.json', config!.configFilePath)
-        })
-    })
-    describe('getChildConfigurations()', () => {
-        beforeEach(async () => {
-            memfs = new InMemoryFileSystem('/')
-            const localfs = new MapFileSystem(new Map([
-                ['file:///tsconfig.json', '{}'],
-                ['file:///foo/bar/tsconfig.json', '{}'],
-                ['file:///foo/baz/tsconfig.json', '{}']
-            ]))
-            const updater = new FileSystemUpdater(localfs, memfs)
-            projectManager = new ProjectManager('/', memfs, updater, true)
-            await projectManager.ensureAllFiles().toPromise()
-        })
-        it('should resolve best configuration based on file name', () => {
-            const configs = Array.from(projectManager.getChildConfigurations('file:///foo')).map(config => config.configFilePath)
-            assert.deepEqual(configs, [
-                '/foo/bar/tsconfig.json',
-                '/foo/baz/tsconfig.json'
-            ])
-        })
-    })
+    for (const rootUri of ['file:///', 'file:///c:/foo/bar/', 'file:///foo/bar/']) {
+        testWithRootUri(rootUri)
+    }
 })
+
+function testWithRootUri(rootUri: string): void {
+    describe(`with rootUri ${rootUri}`, () => {
+
+        let projectManager: ProjectManager
+        let memfs: InMemoryFileSystem
+
+        it('should add a ProjectConfiguration when a tsconfig.json is added to the InMemoryFileSystem', () => {
+            const rootPath = uri2path(rootUri)
+            memfs = new InMemoryFileSystem(rootPath)
+            const configFileUri = rootUri + 'foo/tsconfig.json'
+            const localfs = new MapFileSystem(new Map([
+                [configFileUri, '{}']
+            ]))
+            const updater = new FileSystemUpdater(localfs, memfs)
+            projectManager = new ProjectManager(rootPath, memfs, updater, true)
+            memfs.add(configFileUri, '{}')
+            const configs = Array.from(projectManager.configurations())
+            const expectedConfigFilePath = uri2path(configFileUri)
+
+            assert.isDefined(configs.find(config => config.configFilePath === expectedConfigFilePath))
+        })
+
+        describe('ensureBasicFiles', () => {
+            beforeEach(async () => {
+                const rootPath = uri2path(rootUri)
+                memfs = new InMemoryFileSystem(rootPath)
+                const localfs = new MapFileSystem(new Map([
+                    [rootUri + 'project/package.json', '{"name": "package-name-1"}'],
+                    [rootUri + 'project/tsconfig.json', '{ "compilerOptions": { "typeRoots": ["../types"]} }'],
+                    [rootUri + 'project/file.ts', 'console.log(GLOBALCONSTANT);'],
+                    [rootUri + 'types/types.d.ts', 'declare var GLOBALCONSTANT=1;']
+
+                ]))
+                const updater = new FileSystemUpdater(localfs, memfs)
+                projectManager = new ProjectManager(rootPath, memfs, updater, true)
+            })
+            it('loads files from typeRoots', async () => {
+                await projectManager.ensureReferencedFiles(rootUri + 'project/file.ts').toPromise()
+                memfs.getContent(rootUri + 'project/file.ts')
+                memfs.getContent(rootUri + 'types/types.d.ts')
+            })
+        })
+
+        describe('getPackageName()', () => {
+            beforeEach(async () => {
+                const rootPath = uri2path(rootUri)
+                memfs = new InMemoryFileSystem(rootPath)
+                const localfs = new MapFileSystem(new Map([
+                    [rootUri + 'package.json', '{"name": "package-name-1"}'],
+                    [rootUri + 'subdirectory-with-tsconfig/package.json', '{"name": "package-name-2"}'],
+                    [rootUri + 'subdirectory-with-tsconfig/src/tsconfig.json', '{}'],
+                    [rootUri + 'subdirectory-with-tsconfig/src/dummy.ts', '']
+                ]))
+                const updater = new FileSystemUpdater(localfs, memfs)
+                projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                await projectManager.ensureAllFiles().toPromise()
+            })
+        })
+
+        describe('ensureReferencedFiles()', () => {
+            beforeEach(() => {
+                const rootPath = uri2path(rootUri)
+                memfs = new InMemoryFileSystem(rootPath)
+                const localfs = new MapFileSystem(new Map([
+                    [rootUri + 'package.json', '{"name": "package-name-1"}'],
+                    [rootUri + 'node_modules/somelib/index.js', '/// <reference path="./pathref.d.ts"/>\n/// <reference types="node"/>'],
+                    [rootUri + 'node_modules/somelib/pathref.d.ts', ''],
+                    [rootUri + 'node_modules/%40types/node/index.d.ts', ''],
+                    [rootUri + 'src/dummy.ts', 'import * as somelib from "somelib";']
+                ]))
+                const updater = new FileSystemUpdater(localfs, memfs)
+                projectManager = new ProjectManager(rootPath, memfs, updater, true)
+            })
+            it('should ensure content for imports and references is fetched', async () => {
+                await projectManager.ensureReferencedFiles(rootUri + 'src/dummy.ts').toPromise()
+                memfs.getContent(rootUri + 'node_modules/somelib/index.js')
+                memfs.getContent(rootUri + 'node_modules/somelib/pathref.d.ts')
+                memfs.getContent(rootUri + 'node_modules/%40types/node/index.d.ts')
+            })
+        })
+        describe('getConfiguration()', () => {
+            beforeEach(async () => {
+                const rootPath = uri2path(rootUri)
+                memfs = new InMemoryFileSystem(rootPath)
+                const localfs = new MapFileSystem(new Map([
+                    [rootUri + 'tsconfig.json', '{}'],
+                    [rootUri + 'src/jsconfig.json', '{}']
+                ]))
+                const updater = new FileSystemUpdater(localfs, memfs)
+                projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                await projectManager.ensureAllFiles().toPromise()
+            })
+            it('should resolve best configuration based on file name', () => {
+                const jsConfig = projectManager.getConfiguration(uri2path(rootUri + 'src/foo.js'))
+                const tsConfig = projectManager.getConfiguration(uri2path(rootUri + 'src/foo.ts'))
+                assert.equal(uri2path(rootUri + 'tsconfig.json'), tsConfig.configFilePath)
+                assert.equal(uri2path(rootUri + 'src/jsconfig.json'), jsConfig.configFilePath)
+                assert.equal(Array.from(projectManager.configurations()).length, 2)
+            })
+        })
+        describe('getParentConfiguration()', () => {
+            beforeEach(async () => {
+                const rootPath = uri2path(rootUri)
+                memfs = new InMemoryFileSystem(rootPath)
+                const localfs = new MapFileSystem(new Map([
+                    [rootUri + 'tsconfig.json', '{}'],
+                    [rootUri + 'src/jsconfig.json', '{}']
+                ]))
+                const updater = new FileSystemUpdater(localfs, memfs)
+                projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                await projectManager.ensureAllFiles().toPromise()
+            })
+            it('should resolve best configuration based on file name', () => {
+                const config = projectManager.getParentConfiguration(rootUri + 'src/foo.ts')
+                assert.isDefined(config)
+                assert.equal(uri2path(rootUri + 'tsconfig.json'), config!.configFilePath)
+                assert.equal(Array.from(projectManager.configurations()).length, 2)
+            })
+        })
+        describe('getChildConfigurations()', () => {
+            beforeEach(async () => {
+                const rootPath = uri2path(rootUri)
+                memfs = new InMemoryFileSystem(rootPath)
+                const localfs = new MapFileSystem(new Map([
+                    [rootUri + 'tsconfig.json', '{}'],
+                    [rootUri + 'foo/bar/tsconfig.json', '{}'],
+                    [rootUri + 'foo/baz/tsconfig.json', '{}']
+                ]))
+                const updater = new FileSystemUpdater(localfs, memfs)
+                projectManager = new ProjectManager(rootPath, memfs, updater, true)
+                await projectManager.ensureAllFiles().toPromise()
+            })
+            it('should resolve best configuration based on file name', () => {
+                const configs = Array.from(projectManager.getChildConfigurations(rootUri + 'foo')).map(config => config.configFilePath)
+                assert.deepEqual(configs, [
+                    uri2path(rootUri + 'foo/bar/tsconfig.json'),
+                    uri2path(rootUri + 'foo/baz/tsconfig.json')
+                ])
+                assert.equal(Array.from(projectManager.configurations()).length, 4)
+            })
+        })
+    })
+}


### PR DESCRIPTION
This PR now contains 3 fixes for Windows path handling caused by two inconsistencies

The first inconsistency existed between `expectedFiles` (unix paths) and `typeRoots` (windows paths)

**Typings from e.g. jasmine/mocha not resolved by Typescript**

Repro: Open any test file in this project, receive diagnostics about not finding `it` and `describe`
Cause: Files were loaded in memory, but `ensureBasicFiles` passed windows paths into unix-style path filters (`isGlobalTsFile`).
Fix: Convert to unix paths before passing to filter methods in `ensureBasicFiles` (https://github.com/sourcegraph/javascript-typescript-langserver/commit/7f57e21bc71fa02b9533ebe0fafeb608a5ab7dd9)
Test: ✅ Added in https://github.com/sourcegraph/javascript-typescript-langserver/pull/362/commits/6d9d3d0f34d5354e924d25468cbd2a15376fec30

After this fix, `isExpectedDeclarationFile` now expected a unixPath, causing a new issue:

**Typings from typeRoots not resolved by Typescript**

Repro: Open a project using typeRoots, receive diagnostics about not finding types from typeRoots
Cause: Files from typeRoots were not loaded into memory by `ensureConfigDependencies` as it was still passing Windows paths into the now unix-path-based `isConfigDependency`
Fix: Make `typeRoots` unix-path based so it is consistent with checks against `expectedFiles`. (https://github.com/sourcegraph/javascript-typescript-langserver/commit/f0c8e02fdd58465e415adbd673151a45952bdf38)
Test: ✅ Updated to check host in https://github.com/sourcegraph/javascript-typescript-langserver/pull/362/commits/6d9d3d0f34d5354e924d25468cbd2a15376fec30

This fixed the type resolution issues I had been seeing while working on Windows. :tada:

To add test coverage, I made the ProjectManager tests use different rootUris. This did not cover the above issues, but it did uncover another inconsistency:

**Windows `rootPath` not handled correctly for configuration lookups in ProjectManager**

When ProjectManager is constructed with a Windows `rootPath`:
* It is not trimmed correctly (see `trimmedRootPath`)
* It puts Windows paths into `this.configs` which otherwise uses unix paths. 

Impact: My guess is default configurations did not work on windows, as they were windows-style and the rest of the code assumed unix-style paths were used..
Fix: Handle `rootPath` and configuration lookups in a platform-sensitive way (because there is no need to normalise to unix paths here?)
