### PR TITLE
Only return InsertTextFormat.Snippet when a snippet is returned

### DIFF
--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2457,7 +2457,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
                     kind: CompletionItemKind.Property,
                     documentation: 'qux doc',
                     sortText: '0',
-                    insertTextFormat: InsertTextFormat.Snippet,
+                    insertTextFormat: InsertTextFormat.PlainText,
                     insertText: 'qux',
                     detail: '(property) A.qux: number',
                     data: undefined

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1093,19 +1093,15 @@ export class TypeScriptService {
                 if (details) {
                     item.documentation = ts.displayPartsToString(details.documentation)
                     item.detail = ts.displayPartsToString(details.displayParts)
-                    if (this.supportsCompletionWithSnippets) {
+                    if (this.supportsCompletionWithSnippets &&
+                        (details.kind === 'method' || details.kind === 'function')) {
+                        const parameters = details.displayParts
+                            .filter(p => p.kind === 'parameterName')
+                            // tslint:disable-next-line:no-invalid-template-strings
+                            .map((p, i) => '${' + `${i + 1}:${p.text}` + '}')
+                        const paramString = parameters.join(', ')
+                        item.insertText = details.name + `(${paramString})`
                         item.insertTextFormat = InsertTextFormat.Snippet
-                        if (details.kind === 'method' || details.kind === 'function') {
-                            const parameters = details.displayParts
-                                .filter(p => p.kind === 'parameterName')
-                                // tslint:disable-next-line:no-invalid-template-strings
-                                .map((p, i) => '${' + `${i + 1}:${p.text}` + '}')
-                            const paramString = parameters.join(', ')
-                            item.insertText = details.name + `(${paramString})`
-                        } else {
-                            item.insertText = details.name
-
-                        }
                     } else {
                         item.insertTextFormat = InsertTextFormat.PlainText
                         item.insertText = details.name


### PR DESCRIPTION
The language server was returning InsertTextFormat.Snippet all the time when a client indicated it supported snippets.

The more correct behaviour is to only return that value when insertText is actually a snippet.
This allows clients to avoid potentially more complex completion handling when not necessary.