### PR TITLE
Update to Typescript 2.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rxjs": "^5.5.0",
     "semaphore-async-await": "^1.5.1",
     "string-similarity": "^1.1.0",
-    "typescript": "2.4.2",
+    "typescript": "2.5.2",
     "vscode-jsonrpc": "^3.3.1",
     "vscode-languageserver": "^3.1.0",
     "vscode-languageserver-types": "^3.0.3"

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2326,7 +2326,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
                 '}',
                 'const a = new A();',
                 'a.',
-                ''
+                '',
             ].join('\n')],
         ]), {
             textDocument: {
@@ -2482,18 +2482,18 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
                 '}',
                 'const a = new A();',
                 'a.',
-                ''
+                '',
             ].join('\n')],
             [rootUri + 'uses-import.ts', [
                 'import * as i from "./import"',
                 'i.',
-                ''
+                '',
             ].join('\n')],
             [rootUri + 'import.ts', '/** d doc*/ export function d() {}'],
             [rootUri + 'uses-reference.ts', [
                 '/// <reference path="reference.ts" />',
                 'let z : foo. ',
-                ''
+                '',
             ].join('\n')],
             [rootUri + 'reference.ts', [
                 'namespace foo {',

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2326,6 +2326,7 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
                 '}',
                 'const a = new A();',
                 'a.',
+                ''
             ].join('\n')],
         ]), {
             textDocument: {
@@ -2481,15 +2482,18 @@ export function describeTypeScriptService(createService: TypeScriptServiceFactor
                 '}',
                 'const a = new A();',
                 'a.',
+                ''
             ].join('\n')],
             [rootUri + 'uses-import.ts', [
                 'import * as i from "./import"',
                 'i.',
+                ''
             ].join('\n')],
             [rootUri + 'import.ts', '/** d doc*/ export function d() {}'],
             [rootUri + 'uses-reference.ts', [
                 '/// <reference path="reference.ts" />',
-                'let z : foo.',
+                'let z : foo. ',
+                ''
             ].join('\n')],
             [rootUri + 'reference.ts', [
                 'namespace foo {',


### PR DESCRIPTION
The fixes turned out really small, I left one test broken to demonstrate the issue:

```
  3) TypeScriptService
       rootUri file:///foo/bar/
         textDocumentCompletion()
           produces completions for empty files:
     Error: Debug Failure. False expression.
      at computePositionOfLineAndCharacter (node_modules/typescript/lib/typescript.js:5364:22)
      at Object.getPositionOfLineAndCharacter (node_modules/typescript/lib/typescript.js:5353:16)
      at MergeMapSubscriber.projectManager.ensureReferencedFiles.toArray.mergeMap [as project] (src/typescript-service.ts:1043:43)
```

Because the completion tests request characters past the end of the file, we are seeing these assertions. The debug checks were made more lenient in https://github.com/Microsoft/TypeScript/pull/18298/files#diff-a15280067dcb3b0929808762f8352e86R340 to be released in 2.6

Changing `empty.ts` to contain more whitespace would allow the test to pass, but that might be against the point of the test.
