### PR TITLE
Empty handler for initialized notification

### DIFF
--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1324,6 +1324,10 @@ export class TypeScriptService {
             .startWith({ op: 'add', path: '', value: { changes: {} } as WorkspaceEdit } as Operation)
     }
 
+    public async initialized(): Promise<void> {
+        // nop
+    }
+
     /**
      * The document open notification is sent from the client to the server to signal newly opened
      * text documents. The document's truth is now managed by the client and the server must not try

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1324,6 +1324,12 @@ export class TypeScriptService {
             .startWith({ op: 'add', path: '', value: { changes: {} } as WorkspaceEdit } as Operation)
     }
 
+    /**
+     * The initialized notification is sent from the client to the server after the client received
+     * the result of the initialize request but before the client is sending any other request or
+     * notification to the server. The server can use the initialized notification for example to
+     * dynamically register capabilities.
+     */
     public async initialized(): Promise<void> {
         // nop
     }


### PR DESCRIPTION
The language server currently logs a warning when the `initialized` notification is received.

As we are not dynamically registering capabilities on the client, there should be nothing to do but silently handle the notification?

See: https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#new-initialized-notification