### PR TITLE
feat(typescript): upgrade to typescript 2.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rxjs": "^5.5.0",
     "semaphore-async-await": "^1.5.1",
     "string-similarity": "^1.1.0",
-    "typescript": "2.4.2",
+    "typescript": "2.6.2",
     "vscode-jsonrpc": "^3.3.1",
     "vscode-languageserver": "^3.1.0",
     "vscode-languageserver-types": "^3.0.3"

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -2297,11 +2297,11 @@ export function describeTypeScriptService(
                             uri: 'git://github.com/Microsoft/TypeScript?v' + ts.version + '#lib/lib.dom.d.ts',
                             range: {
                                 start: {
-                                    line: 8259,
+                                    line: 8428,
                                     character: 10,
                                 },
                                 end: {
-                                    line: 8259,
+                                    line: 8428,
                                     character: 14,
                                 },
                             },
@@ -2310,11 +2310,11 @@ export function describeTypeScriptService(
                             uri: 'git://github.com/Microsoft/TypeScript?v' + ts.version + '#lib/lib.dom.d.ts',
                             range: {
                                 start: {
-                                    line: 8311,
+                                    line: 8480,
                                     character: 12,
                                 },
                                 end: {
-                                    line: 8311,
+                                    line: 8480,
                                     character: 16,
                                 },
                             },
@@ -3028,7 +3028,7 @@ export function describeTypeScriptService(
                     },
                     position: {
                         line: 1,
-                        character: 13,
+                        character: 12,
                     },
                 })
                 .reduce<Operation, CompletionList>(applyReducer, null as any)
@@ -3039,7 +3039,7 @@ export function describeTypeScriptService(
                     {
                         data: {
                             entryName: 'bar',
-                            offset: 51,
+                            offset: 50,
                             uri: rootUri + 'uses-reference.ts',
                         },
                         label: 'bar',

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -100,25 +100,25 @@ export interface Settings extends PluginSettings {
 /**
  * Maps string-based CompletionEntry::kind to enum-based CompletionItemKind
  */
-const completionKinds: { [name: string]: CompletionItemKind } = {
-    class: CompletionItemKind.Class,
-    constructor: CompletionItemKind.Constructor,
-    enum: CompletionItemKind.Enum,
-    field: CompletionItemKind.Field,
-    file: CompletionItemKind.File,
-    function: CompletionItemKind.Function,
-    interface: CompletionItemKind.Interface,
-    keyword: CompletionItemKind.Keyword,
-    method: CompletionItemKind.Method,
-    module: CompletionItemKind.Module,
-    property: CompletionItemKind.Property,
-    reference: CompletionItemKind.Reference,
-    snippet: CompletionItemKind.Snippet,
-    text: CompletionItemKind.Text,
-    unit: CompletionItemKind.Unit,
-    value: CompletionItemKind.Value,
-    variable: CompletionItemKind.Variable,
-}
+const completionKinds = new Map<string, CompletionItemKind>([
+    [`class`, CompletionItemKind.Class],
+    [`constructor`, CompletionItemKind.Constructor],
+    [`enum`, CompletionItemKind.Enum],
+    [`field`, CompletionItemKind.Field],
+    [`file`, CompletionItemKind.File],
+    [`function`, CompletionItemKind.Function],
+    [`interface`, CompletionItemKind.Interface],
+    [`keyword`, CompletionItemKind.Keyword],
+    [`method`, CompletionItemKind.Method],
+    [`module`, CompletionItemKind.Module],
+    [`property`, CompletionItemKind.Property],
+    [`reference`, CompletionItemKind.Reference],
+    [`snippet`, CompletionItemKind.Snippet],
+    [`text`, CompletionItemKind.Text],
+    [`unit`, CompletionItemKind.Unit],
+    [`value`, CompletionItemKind.Value],
+    [`variable`, CompletionItemKind.Variable],
+])
 
 /**
  * Handles incoming requests and return responses. There is a one-to-one-to-one
@@ -1182,7 +1182,7 @@ export class TypeScriptService {
                     params.position.line,
                     params.position.character
                 )
-                const completions = configuration.getService().getCompletionsAtPosition(fileName, offset)
+                const completions = configuration.getService().getCompletionsAtPosition(fileName, offset, undefined)
 
                 if (!completions) {
                     return []
@@ -1192,7 +1192,7 @@ export class TypeScriptService {
                     .map(entry => {
                         const item: CompletionItem = { label: entry.name }
 
-                        const kind = completionKinds[entry.kind]
+                        const kind = completionKinds.get(entry.kind)
                         if (kind) {
                             item.kind = kind
                         }
@@ -1233,7 +1233,10 @@ export class TypeScriptService {
                 const configuration = this.projectManager.getConfiguration(fileName)
                 configuration.ensureBasicFiles(span)
 
-                const details = configuration.getService().getCompletionEntryDetails(fileName, offset, entryName)
+                const details = configuration
+                    .getService()
+                    .getCompletionEntryDetails(fileName, offset, entryName, undefined, undefined)
+
                 if (details) {
                     item.documentation = ts.displayPartsToString(details.documentation)
                     item.detail = ts.displayPartsToString(details.displayParts)


### PR DESCRIPTION
This change updates TypeScript to 2.6.2, the latest stable version.  We had to make some changes to address [API breaking changes](https://github.com/Microsoft/TypeScript/wiki/API-Breaking-Changes#typescript-26) and a compiler change which required the code [here](https://github.com/sourcegraph/javascript-typescript-langserver/pull/430/files#diff-7a192e75048b31deb4cc6b82f30f91e8R105) to change to avoid the use of `constructor` as an object key.

Please let us know if there's anything else we can change to get this accepted!

Resolves https://github.com/sourcegraph/javascript-typescript-langserver/pull/359

/cc @damieng