### PR TITLE
Add missing project method for plugins

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -40,7 +40,7 @@ export interface PluginCreateInfo {
  * The portion of tsserver's Project API exposed to plugins
  */
 export interface Project {
-    getCurrentDirectory: () => string,
+    getCurrentDirectory: () => string
     projectService: {
         logger: Logger
     }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -40,6 +40,7 @@ export interface PluginCreateInfo {
  * The portion of tsserver's Project API exposed to plugins
  */
 export interface Project {
+    getCurrentDirectory: () => string,
     projectService: {
         logger: Logger
     }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -40,10 +40,8 @@ export interface PluginCreateInfo {
  * The portion of tsserver's Project API exposed to plugins
  */
 export interface Project {
+    projectService: { logger: Logger }
     getCurrentDirectory(): string
-    projectService: {
-        logger: Logger
-    }
 }
 
 /**

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -40,7 +40,7 @@ export interface PluginCreateInfo {
  * The portion of tsserver's Project API exposed to plugins
  */
 export interface Project {
-    getCurrentDirectory: () => string
+    getCurrentDirectory(): string
     projectService: {
         logger: Logger
     }

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -385,10 +385,11 @@ export class ProjectConfiguration {
 
             const info: PluginCreateInfo = {
                 config: configEntry,
-                project: { // TODO: may need more support
-                    getCurrentDirectory: this.getHost().getCurrentDirectory,
+                project: {
+                    // TODO: may need more support
+                    getCurrentDirectory: this.getHost().getCurrentDirectory.bind(this),
                     projectService: { logger: this.logger },
-                }, 
+                },
                 languageService: this.getService(),
                 languageServiceHost: this.getHost(),
                 serverHost: {}, // TODO: may need an adapter

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -385,7 +385,10 @@ export class ProjectConfiguration {
 
             const info: PluginCreateInfo = {
                 config: configEntry,
-                project: { projectService: { logger: this.logger } }, // TODO: may need more support
+                project: { // TODO: may need more support
+                    getCurrentDirectory: this.getHost().getCurrentDirectory,
+                    projectService: { logger: this.logger },
+                }, 
                 languageService: this.getService(),
                 languageServiceHost: this.getHost(),
                 serverHost: {}, // TODO: may need an adapter

--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -387,7 +387,7 @@ export class ProjectConfiguration {
                 config: configEntry,
                 project: {
                     // TODO: may need more support
-                    getCurrentDirectory: this.getHost().getCurrentDirectory.bind(this),
+                    getCurrentDirectory: () => this.getHost().getCurrentDirectory(),
                     projectService: { logger: this.logger },
                 },
                 languageService: this.getService(),


### PR DESCRIPTION
I'm using [tslint-language-service](https://github.com/angelozerr/tslint-language-service/issues), and this plugin doesn't work with javascript-typescript-langserver because there is some missing properties/methods in your PluginCreateInfo. So I just added the `getCurrentDirectory`.