### PR TITLE
fix(imports): stop using import assignment (for ECMAScript modules)

### DIFF
--- a/src/test/fs.test.ts
+++ b/src/test/fs.test.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai'
-import chaiAsPromised = require('chai-as-promised')
+import * as chaiAsPromised from 'chai-as-promised'
 import * as fs from 'mz/fs'
 import * as path from 'path'
 import * as rimraf from 'rimraf'

--- a/src/test/memfs.test.ts
+++ b/src/test/memfs.test.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai'
-import chaiAsPromised = require('chai-as-promised')
+import * as chaiAsPromised from 'chai-as-promised'
 import iterate from 'iterare'
 import * as sinon from 'sinon'
 import { InMemoryFileSystem, typeScriptLibraries } from '../memfs'

--- a/src/test/project-manager.test.ts
+++ b/src/test/project-manager.test.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai'
-import chaiAsPromised = require('chai-as-promised')
+import * as chaiAsPromised from 'chai-as-promised'
 import { FileSystemUpdater } from '../fs'
 import { InMemoryFileSystem } from '../memfs'
 import { ProjectManager } from '../project-manager'

--- a/src/test/tracing.test.ts
+++ b/src/test/tracing.test.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai'
-import chaiAsPromised = require('chai-as-promised')
+import * as chaiAsPromised from 'chai-as-promised'
 import { Span } from 'opentracing'
 import { Observable } from 'rxjs'
 import * as sinon from 'sinon'

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai'
-import chaiAsPromised = require('chai-as-promised')
+import * as chaiAsPromised from 'chai-as-promised'
 import { applyReducer, Operation } from 'fast-json-patch'
 import { IBeforeAndAfterContext, ISuiteCallbackContext, ITestCallbackContext } from 'mocha'
 import { Observable } from 'rxjs'

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -2,7 +2,7 @@ import { Operation } from 'fast-json-patch'
 import iterate from 'iterare'
 import { castArray, merge, omit } from 'lodash'
 import { toPairs } from 'lodash'
-import hashObject = require('object-hash')
+import * as hashObject from 'object-hash'
 import { Span } from 'opentracing'
 import { Observable } from 'rxjs'
 import * as ts from 'typescript'


### PR DESCRIPTION
When trying to compile as ECMAScript modules, errors about import assignment don't allow compilation. This pull request fixes that by changing such to use `import * as XXX from YYY` instead.