### PR TITLE
symbols: do not limit symbols found from config

### DIFF
--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1676,9 +1676,8 @@ export class TypeScriptService {
 
             if (typeof query === 'string') {
                 // Query by text query
-                // Limit the amount of symbols searched for text queries
                 return (
-                    Observable.from(config.getService().getNavigateToItems(query, 100, undefined, false))
+                    Observable.from(config.getService().getNavigateToItems(query))
                         // Exclude dependencies and standard library
                         .filter(
                             item => !isTypeScriptLibrary(item.fileName) && !item.fileName.includes('/node_modules/')


### PR DESCRIPTION
limiting symbols found from config could lead to confusion when broad search term returns less results that more specific one.

Fixes #491