### PR TITLE
Send diagnostics for all open files

### DIFF
--- a/src/project-manager.ts
+++ b/src/project-manager.ts
@@ -239,6 +239,11 @@ export class ProjectConfiguration {
     private expectedFilePaths = new Set<string>()
 
     /**
+     * Set of uris for all files currently open in the editor
+     */
+    public readonly openFiles: Set<string> = new Set<string>()
+
+    /**
      * List of resolved extra root directories to allow global type declaration files to be loaded from.
      * Each item is an absolute UNIX-like file path
      */
@@ -1049,6 +1054,11 @@ export class ProjectManager implements Disposable {
      * @param text file's content
      */
     public didOpen(uri: string, text: string): void {
+        const config = this.getParentConfiguration(uri)
+        if (!config) {
+            return
+        }
+        config.openFiles.add(uri)
         this.didChange(uri, text)
     }
 
@@ -1065,6 +1075,7 @@ export class ProjectManager implements Disposable {
         if (!config) {
             return
         }
+        config.openFiles.delete(uri)
         config.ensureConfigFile(span)
         config.getHost().incProjectVersion()
     }

--- a/src/test/typescript-service-helpers.ts
+++ b/src/test/typescript-service-helpers.ts
@@ -1975,7 +1975,10 @@ export function describeTypeScriptService(
             initializeTypeScriptService(
                 createService,
                 rootUri,
-                new Map([[rootUri + 'src/errors.ts', 'const text: string = 33;']])
+                new Map([
+                    [rootUri + 'src/errors.ts', 'const text: string = 33;'], 
+                    [rootUri + 'src/valid.ts', 'const validText: string = "valid text";']
+                ])
             )
         )
 
@@ -2005,6 +2008,47 @@ export function describeTypeScriptService(
                     },
                 ],
                 uri: rootUri + 'src/errors.ts',
+            })
+        })
+        
+        it('should publish diagnostics for all open files on didOpen', async function(this: TestContext & ITestCallbackContext): Promise<
+            void
+        > {
+            await this.service.textDocumentDidOpen({
+                textDocument: {
+                    uri: rootUri + 'src/errors.ts',
+                    languageId: 'typescript',
+                    text: 'const text: string = 33;',
+                    version: 1,
+                },
+            })
+            
+            this.client.textDocumentPublishDiagnostics.resetHistory()
+            
+            await this.service.textDocumentDidOpen({
+                textDocument: {
+                    uri: rootUri + 'src/valid.ts',
+                    languageId: 'typescript',
+                    text: 'const validText: string = "valid text";',
+                    version: 1,
+                },
+            })
+
+            sinon.assert.calledWith(this.client.textDocumentPublishDiagnostics, {
+                diagnostics: [
+                    {
+                        message: "Type '33' is not assignable to type 'string'.",
+                        range: { end: { character: 10, line: 0 }, start: { character: 6, line: 0 } },
+                        severity: 1,
+                        source: 'ts',
+                        code: 2322,
+                    },
+                ],
+                uri: rootUri + 'src/errors.ts',
+            })            
+            sinon.assert.calledWith(this.client.textDocumentPublishDiagnostics, {
+                diagnostics: [],
+                uri: rootUri + 'src/valid.ts',
             })
         })
 


### PR DESCRIPTION
We want TS LSP server to sent diagnostics for all currently open files.

There's already been a discussion about it https://github.com/sourcegraph/javascript-typescript-langserver/issues/162 but it's been decided to send diagnostics per file. In that case if the IDE wants to keep updated information about open files it should constantly sent lots of requests to LSP server. 

So posting diagnostics not for all files in project but only for the open ones seems like a reasonable compromise. This behavior is similar to what VSCode does. Basically it helps showing errors for all currently open files and handles the situations when some file is fixed by changes in another file (for example in import). 

We want to have the following behavior: 
1. When the file is opened and didOpen is sent, file path is stored in the project configuration openFiles set.
2. When the file is opened (didOpen) or edited (didChange) the diagnostics is posted by LSP server for all the open files that are currently open.
3. When the file is closed (didClose) the empty diagnostics is sent (i.e. errors in this file are no longer tracked by the server) and it's removed from project configuration openFiles.


