### PR TITLE
Set correct range field for errors that have a length of zero

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -4,14 +4,11 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver'
 /**
  * Converts a TypeScript Diagnostic to an LSP Diagnostic
  */
-export function convertTsDiagnostic(diagnostic: ts.Diagnostic): Diagnostic {
+export function convertTsDiagnostic(diagnostic: ts.DiagnosticWithLocation): Diagnostic {
     const text = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
-    let range: Range = { start: { character: 0, line: 0 }, end: { character: 0, line: 0 } }
-    if (diagnostic.file && diagnostic.start && diagnostic.length) {
-        range = {
-            start: diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start),
-            end: diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start + diagnostic.length),
-        }
+    const range: Range =  {
+        start: diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start),
+        end: diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start + diagnostic.length),
     }
     return {
         range,

--- a/src/typescript-service.ts
+++ b/src/typescript-service.ts
@@ -1645,6 +1645,10 @@ export class TypeScriptService {
                     .filter((e): e is ts.DiagnosticWithLocation => !!e.file)
             )
         const diagnostics = iterate(tsDiagnostics)
+            // TS can report diagnostics without a file and range in some cases
+            // These cannot be represented as LSP Diagnostics since the range and URI is required
+            // https://github.com/Microsoft/TypeScript/issues/15666
+            .filter(diagnostic => !!diagnostic.file && diagnostic.start !== undefined && diagnostic.length !== undefined)
             .map(convertTsDiagnostic)
             .toArray()
         this.client.textDocumentPublishDiagnostics({ uri, diagnostics })


### PR DESCRIPTION
The server is sending invalid diagnostics line if error length is zero. 